### PR TITLE
03 - Properly handle URI paths with escaped/escapable characters

### DIFF
--- a/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/rest/TrinoS3ProxyResource.java
+++ b/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/rest/TrinoS3ProxyResource.java
@@ -135,6 +135,7 @@ public class TrinoS3ProxyResource
             throw new WebApplicationException(Response.Status.NOT_FOUND);
         }
         path = path.substring(s3Path.length());
+
         if (path.isEmpty()) {
             path = "/";
         }


### PR DESCRIPTION
We need to maintain encoded paths for signatures and the remote request. Add a raw version of the parsed S3 path that can be used to build signatures and build the remote URI.

Added a test for this.