### PR TITLE
03 - Inject and manage common objects via a request filter

### DIFF
--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/RequestFilter.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/RequestFilter.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.aws.proxy.server.rest;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.trino.aws.proxy.spi.rest.Request;
+import io.trino.aws.proxy.spi.signing.SigningController;
+import io.trino.aws.proxy.spi.signing.SigningMetadata;
+import io.trino.aws.proxy.spi.signing.SigningServiceType;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ContainerResponse;
+import org.glassfish.jersey.server.model.Parameter;
+import org.glassfish.jersey.server.spi.internal.ValueParamProvider;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static java.util.Objects.requireNonNull;
+import static org.glassfish.jersey.server.spi.internal.ValueParamProvider.Priority.HIGH;
+
+public class RequestFilter
+        implements ContainerRequestFilter, ContainerResponseFilter, ValueParamProvider
+{
+    private final Logger log = Logger.get(RequestFilter.class);
+    private final SigningController signingController;
+    private final Map<Class<?>, SigningServiceType> signingServiceTypesMap;
+    private final RequestLoggerController requestLoggerController;
+
+    private record InternalRequestContext(Request request, SigningMetadata signingMetadata, RequestLoggingSession requestLoggingSession)
+    {
+        private InternalRequestContext
+        {
+            requireNonNull(request, "request is null");
+            requireNonNull(signingMetadata, "signingMetadata is null");
+            requireNonNull(requestLoggingSession, "requestLoggingSession is null");
+        }
+    }
+
+    @Inject
+    RequestFilter(SigningController signingController, Map<Class<?>, SigningServiceType> signingServiceTypesMap, RequestLoggerController requestLoggerController)
+    {
+        this.signingController = requireNonNull(signingController, "signingController is null");
+        this.signingServiceTypesMap = ImmutableMap.copyOf(signingServiceTypesMap);
+        this.requestLoggerController = requireNonNull(requestLoggerController, "requestLoggerController is null");
+    }
+
+    @SuppressWarnings("ThrowableNotThrown")
+    @Override
+    public void filter(ContainerRequestContext requestContext)
+            throws IOException
+    {
+        if (requestContext.getRequest() instanceof ContainerRequest containerRequest) {
+            if (containerRequest.getUriInfo().getMatchedResourceMethod() == null) {
+                log.warn("%s does not have a MatchedResourceMethod", containerRequest.getRequestUri());
+                throw new WebApplicationException(INTERNAL_SERVER_ERROR);
+            }
+
+            Class<?> declaringClass = containerRequest.getUriInfo().getMatchedResourceMethod().getInvocable().getDefinitionMethod().getDeclaringClass();
+            SigningServiceType signingServiceType = signingServiceTypesMap.get(declaringClass);
+            if (signingServiceType == null) {
+                log.warn("%s does not have a SigningServiceType", declaringClass.getName());
+                throw new WebApplicationException(INTERNAL_SERVER_ERROR);
+            }
+
+            Request request = RequestBuilder.fromRequest(containerRequest);
+            RequestLoggingSession requestLoggingSession = requestLoggerController.newRequestSession(request, signingServiceType);
+            containerRequest.setProperty(RequestLoggingSession.class.getName(), requestLoggingSession);
+
+            SigningMetadata signingMetadata;
+            try {
+                signingMetadata = signingController.validateAndParseAuthorization(request, signingServiceType);
+            }
+            catch (Exception e) {
+                requestLoggingSession.logException(e);
+
+                switch (Throwables.getRootCause(e)) {
+                    case WebApplicationException webApplicationException -> throw webApplicationException;
+                    case IOException ioException -> throw ioException;
+                    default -> throw new RuntimeException(e);
+                }
+            }
+
+            containerRequest.setProperty(Request.class.getName(), request);
+            containerRequest.setProperty(SigningMetadata.class.getName(), signingMetadata);
+        }
+        else {
+            log.warn("%s is not a ContainerRequest", requestContext.getRequest().getClass().getName());
+            throw new WebApplicationException(INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+            throws IOException
+    {
+        if ((requestContext.getRequest() instanceof ContainerRequest containerRequest) && (responseContext instanceof ContainerResponse containerResponse)) {
+            Optional.ofNullable(unwrap(containerRequest, RequestLoggingSession.class))
+                    .ifPresent(requestLoggingSession -> {
+                        OutputStream entityStream = (containerResponse.isCommitted() || !containerResponse.hasEntity()) ? null : responseContext.getEntityStream();
+                        if (entityStream != null) {
+                            responseContext.setEntityStream(closingStream(requestLoggingSession, entityStream));
+                        }
+                        else {
+                            requestLoggingSession.close();
+                        }
+                    });
+        }
+    }
+
+    @Override
+    public Function<ContainerRequest, ?> getValueProvider(Parameter parameter)
+    {
+        if (Request.class.isAssignableFrom(parameter.getRawType()) || SigningMetadata.class.isAssignableFrom(parameter.getRawType()) || RequestLoggingSession.class.isAssignableFrom(parameter.getRawType())) {
+            return containerRequest -> unwrap(containerRequest, parameter.getRawType());
+        }
+        return null;
+    }
+
+    @Override
+    public PriorityType getPriority()
+    {
+        return HIGH;
+    }
+
+    private static OutputStream closingStream(Closeable closeable, OutputStream delegate)
+    {
+        return new OutputStream()
+        {
+            @Override
+            public void write(int b)
+                    throws IOException
+            {
+                delegate.write(b);
+            }
+
+            @Override
+            public void write(byte[] b)
+                    throws IOException
+            {
+                delegate.write(b);
+            }
+
+            @Override
+            public void write(byte[] b, int off, int len)
+                    throws IOException
+            {
+                delegate.write(b, off, len);
+            }
+
+            @Override
+            public void flush()
+                    throws IOException
+            {
+                delegate.flush();
+            }
+
+            @Override
+            public void close()
+                    throws IOException
+            {
+                try (closeable) {
+                    delegate.close();
+                }
+            }
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T unwrap(ContainerRequest containerRequest, Class<T> type)
+    {
+        return (T) containerRequest.getProperty(type.getName());
+    }
+}

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/RequestLoggerController.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/RequestLoggerController.java
@@ -23,12 +23,12 @@ import jakarta.annotation.PreDestroy;
 import jakarta.ws.rs.WebApplicationException;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.trino.aws.proxy.spi.rest.RequestContent.ContentType.EMPTY;
+import static java.util.Objects.requireNonNull;
 
 public class RequestLoggerController
 {
@@ -102,9 +102,9 @@ public class RequestLoggerController
         });
     }
 
-    public Optional<RequestLoggingSession> currentRequestSession(UUID requestId)
+    public RequestLoggingSession currentRequestSession(UUID requestId)
     {
-        return Optional.ofNullable(sessions.get(requestId));
+        return requireNonNull(sessions.get(requestId), "No RequestLoggingSession for requestId: " + requestId);
     }
 
     private RequestLoggingSession internalNewRequestSession(Request request, SigningServiceType serviceType)

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/StreamingResponseHandler.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/StreamingResponseHandler.java
@@ -68,24 +68,22 @@ class StreamingResponseHandler
             output.flush();
         };
 
-        try (requestLoggingSession) {
-            jakarta.ws.rs.core.Response.ResponseBuilder responseBuilder = jakarta.ws.rs.core.Response.status(response.getStatusCode());
-            if (HttpStatus.familyForStatusCode(response.getStatusCode()) == HttpStatus.Family.SUCCESSFUL) {
-                responseBuilder.entity(streamingOutput);
-            }
-            response.getHeaders()
-                    .keySet()
-                    .stream()
-                    .map(HeaderName::toString)
-                    .forEach(name -> response.getHeaders(name).forEach(value -> responseBuilder.header(name, value)));
-
-            requestLoggingSession.logProperty("response.status", response.getStatusCode());
-            requestLoggingSession.logProperty("response.headers", response.getHeaders());
-
-            // this will block until StreamingOutput completes
-
-            resume(responseBuilder.build());
+        jakarta.ws.rs.core.Response.ResponseBuilder responseBuilder = jakarta.ws.rs.core.Response.status(response.getStatusCode());
+        if (HttpStatus.familyForStatusCode(response.getStatusCode()) == HttpStatus.Family.SUCCESSFUL) {
+            responseBuilder.entity(streamingOutput);
         }
+        response.getHeaders()
+                .keySet()
+                .stream()
+                .map(HeaderName::toString)
+                .forEach(name -> response.getHeaders(name).forEach(value -> responseBuilder.header(name, value)));
+
+        requestLoggingSession.logProperty("response.status", response.getStatusCode());
+        requestLoggingSession.logProperty("response.headers", response.getHeaders());
+
+        // this will block until StreamingOutput completes
+
+        resume(responseBuilder.build());
 
         return null;
     }

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoStsResource.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoStsResource.java
@@ -25,13 +25,11 @@ import io.trino.aws.proxy.spi.credentials.EmulatedAssumedRole;
 import io.trino.aws.proxy.spi.rest.Request;
 import io.trino.aws.proxy.spi.signing.SigningController;
 import io.trino.aws.proxy.spi.signing.SigningMetadata;
-import io.trino.aws.proxy.spi.signing.SigningServiceType;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.uri.UriComponent;
 
 import java.nio.charset.StandardCharsets;
@@ -39,7 +37,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static io.trino.aws.proxy.server.rest.RequestBuilder.fromRequest;
 import static java.util.Objects.requireNonNull;
 
 public class TrinoStsResource
@@ -60,10 +57,8 @@ public class TrinoStsResource
 
     @SuppressWarnings("SwitchStatementWithTooFewBranches")
     @POST
-    public Response post(@Context ContainerRequest containerRequest)
+    public Response post(@Context Request request, @Context SigningMetadata signingMetadata)
     {
-        Request request = fromRequest(containerRequest);
-        SigningMetadata signingMetadata = signingController.validateAndParseAuthorization(request, SigningServiceType.STS);
         Map<String, String> arguments = deserializeRequest(request.requestQueryParameters(), request.requestContent().standardBytes());
 
         String action = Optional.ofNullable(arguments.get("Action")).orElse("");

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/signing/InternalSigningController.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/signing/InternalSigningController.java
@@ -154,6 +154,7 @@ public class InternalSigningController
                 entity);
     }
 
+    @SuppressWarnings("resource")
     private Optional<SigningMetadata> isValidAuthorization(
             SigningMetadata metadata,
             Request request,
@@ -181,7 +182,7 @@ public class InternalSigningController
             }
 
             requestLoggerController.currentRequestSession(request.requestId())
-                    .ifPresent(requestLoggingSession -> requestLoggingSession.logError("request.security.authorization.mismatch", ImmutableMap.of("request", requestAuthorization, "generated", generatedAuthorization)));
+                    .logError("request.security.authorization.mismatch", ImmutableMap.of("request", requestAuthorization, "generated", generatedAuthorization));
             return Stream.of();
         }).findFirst();
     }


### PR DESCRIPTION
Remove the burden of allocating and managing common objects from handlers, endpoints, etc. and use a Request filter to do all the work. This has the additional benefit of adding security to every request without the need for developer discipline.

Note: you can see how this improves on the request logging PR in that the creation and closing of the request logging session is now auto-managed.