### PR TITLE
Remove duplicated session field

### DIFF
--- a/trino-aws-proxy-spi/src/main/java/io/trino/aws/proxy/spi/credentials/EmulatedAssumedRole.java
+++ b/trino-aws-proxy-spi/src/main/java/io/trino/aws/proxy/spi/credentials/EmulatedAssumedRole.java
@@ -17,12 +17,11 @@ import java.time.Instant;
 
 import static java.util.Objects.requireNonNull;
 
-public record EmulatedAssumedRole(Credential credential, String session, String arn, String roleId, Instant expiration)
+public record EmulatedAssumedRole(Credential emulatedCredential, String arn, String roleId, Instant expiration)
 {
     public EmulatedAssumedRole
     {
-        requireNonNull(credential, "credential is null");
-        requireNonNull(session, "session is null");
+        requireNonNull(emulatedCredential, "emulatedCredential is null");
         requireNonNull(arn, "arn is null");
         requireNonNull(roleId, "roleId is null");
         requireNonNull(expiration, "expiration is null");

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/AbstractTestStsRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/AbstractTestStsRequests.java
@@ -62,6 +62,6 @@ public abstract class AbstractTestStsRequests
 
         Optional<Credentials> credentials = credentialsProvider.credentials(awsCredentials.accessKeyId(), Optional.of(awsCredentials.sessionToken()));
         assertThat(credentials).isNotEmpty();
-        assertThat(credentials.map(Credentials::emulated)).contains(new Credential(awsCredentials.accessKeyId(), awsCredentials.secretAccessKey()));
+        assertThat(credentials.map(Credentials::emulated)).contains(new Credential(awsCredentials.accessKeyId(), awsCredentials.secretAccessKey(), Optional.of(awsCredentials.sessionToken())));
     }
 }

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/credentials/TestAssumingRoles.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/credentials/TestAssumingRoles.java
@@ -67,7 +67,7 @@ public class TestAssumingRoles
                 .orElseThrow(() -> new RuntimeException("Failed to assume role"));
 
         try (S3Client client = clientBuilder(localS3URI)
-                .credentialsProvider(() -> AwsSessionCredentials.create(emulatedAssumedRole.credential().accessKey(), emulatedAssumedRole.credential().secretKey(), emulatedAssumedRole.session()))
+                .credentialsProvider(() -> AwsSessionCredentials.create(emulatedAssumedRole.emulatedCredential().accessKey(), emulatedAssumedRole.emulatedCredential().secretKey(), emulatedAssumedRole.emulatedCredential().session().orElseThrow()))
                 .build()) {
             // valid assumed role session - should work
             ListBucketsResponse listBucketsResponse = client.listBuckets();

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/TestingCredentialsRolesProvider.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/TestingCredentialsRolesProvider.java
@@ -89,11 +89,11 @@ public class TestingCredentialsRolesProvider
         return Optional.ofNullable(credentials.get(originalEmulatedAccessKey))
                 .map(internal -> {
                     String sessionToken = UUID.randomUUID().toString();
-                    Session session = new Session(new Credential(UUID.randomUUID().toString(), UUID.randomUUID().toString()), originalEmulatedAccessKey, Instant.now().plusSeconds(TimeUnit.HOURS.toSeconds(1)));
+                    Session session = new Session(new Credential(UUID.randomUUID().toString(), UUID.randomUUID().toString(), Optional.of(sessionToken)), originalEmulatedAccessKey, Instant.now().plusSeconds(TimeUnit.HOURS.toSeconds(1)));
 
                     assumedRoleSessions.put(sessionToken, session);
 
-                    return new EmulatedAssumedRole(session.sessionCredential, sessionToken, requestArn, UUID.randomUUID().toString(), session.expiration);
+                    return new EmulatedAssumedRole(session.sessionCredential, requestArn, UUID.randomUUID().toString(), session.expiration);
                 });
     }
 


### PR DESCRIPTION
Remove the duplicated session field in `EmulatedAssumedRole`. This record already contains a `Credential`, which itself has a session token.