### PR TITLE
Have metastore connect directly to remote

### DIFF
--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/containers/S3Container.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/containers/S3Container.java
@@ -129,12 +129,17 @@ public class S3Container
 
         storageClient = S3Client.builder()
                 .region(Region.US_EAST_1)
-                .endpointOverride(URI.create(container.getS3URL()))
+                .endpointOverride(endpoint())
                 .forcePathStyle(true)
                 .credentialsProvider(() -> AwsBasicCredentials.create(credential.accessKey(), credential.secretKey()))
                 .build();
 
         policyUserCredential = new Credential(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+    }
+
+    public URI endpoint()
+    {
+        return URI.create(container.getS3URL());
     }
 
     public HostAndPort containerHost()


### PR DESCRIPTION
The Metastore is a trusted resource. It doesn't need to go through the proxy. Change the test container to connect directly to the object store.

This will be needed for future work with presigned URL redirects.