### PR TITLE
Rewrite of AWS Chunked support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
         <dep.jersey.version>3.1.7</dep.jersey.version>
         <dep.testcontainers.version>1.19.8</dep.testcontainers.version>
         <dep.minio.version>8.5.9</dep.minio.version>
-        <dep.commons-httpclient.version>3.1</dep.commons-httpclient.version>
         <dep.docker.version>3.3.6</dep.docker.version>
         <dep.awaitility.version>4.1.1</dep.awaitility.version>
     </properties>
@@ -92,22 +91,6 @@
                 <groupId>com.github.docker-java</groupId>
                 <artifactId>docker-java-api</artifactId>
                 <version>${dep.docker.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-httpclient</groupId>
-                <artifactId>commons-httpclient</artifactId>
-                <version>${dep.commons-httpclient.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-codec</groupId>
-                        <artifactId>commons-codec</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>

--- a/trino-aws-proxy/pom.xml
+++ b/trino-aws-proxy/pom.xml
@@ -45,11 +45,6 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
         </dependency>

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoS3ProxyClient.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoS3ProxyClient.java
@@ -172,7 +172,7 @@ public class TrinoS3ProxyClient
     private Optional<InputStream> contentInputStream(RequestContent requestContent, SigningMetadata signingMetadata)
     {
         return switch (requestContent.contentType()) {
-            case AWS_CHUNKED -> requestContent.inputStream().map(inputStream -> new AwsChunkedInputStream(inputStream, Optional.of(signingMetadata.requiredSigningContext().chunkSigningSession())));
+            case AWS_CHUNKED -> requestContent.inputStream().map(inputStream -> new AwsChunkedInputStream(inputStream, signingMetadata.requiredSigningContext().chunkSigningSession()));
 
             case STANDARD, W3C_CHUNKED -> requestContent.inputStream().map(inputStream -> {
                 SigningContext signingContext = signingMetadata.requiredSigningContext();

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/rest/TestAwsChunkedInputStream.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/rest/TestAwsChunkedInputStream.java
@@ -1,0 +1,348 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.aws.proxy.server.rest;
+
+import com.google.common.io.ByteStreams;
+import io.trino.aws.proxy.server.signing.TestingChunkSigningSession;
+import io.trino.aws.proxy.spi.credentials.Credential;
+import io.trino.aws.proxy.spi.signing.ChunkSigningSession;
+import jakarta.ws.rs.WebApplicationException;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.stream.Stream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TestAwsChunkedInputStream
+{
+    private static final Credential GOOD_CREDENTIAL = new Credential("TEST_ACCESS_KEY", "TEST_SECRET_KEY");
+    private static final String GOOD_CONTENT = "The quick brown fox jumps over the lazy dog's head";
+    private static final String GOOD_SEED = "THIS IS A FAKE GOOD SEED";
+
+    private static final Credential BAD_CREDENTIAL = new Credential("BAD_TEST_ACCESS_KEY", "BAD_TEST_SECRET_KEY");
+    private static final String BAD_SEED = "THIS IS A FAKE BAD SEED";
+
+    @Test
+    public void testGood()
+            throws IOException
+    {
+        TestingChunkSigningSession signingSession = TestingChunkSigningSession.build(GOOD_CREDENTIAL, GOOD_SEED);
+        String chunkedStream = signingSession.generateChunkedStream(GOOD_CONTENT, 3);
+
+        assertThat(readChunked(chunkedStream, signingSession)).isEqualTo(GOOD_CONTENT.getBytes(UTF_8));
+    }
+
+    @Test
+    public void testRecreateSessionValidatesGoodPayload()
+            throws IOException
+    {
+        TestingChunkSigningSession signingSession = TestingChunkSigningSession.build(GOOD_CREDENTIAL, GOOD_SEED);
+        String chunkedStream = signingSession.generateChunkedStream(GOOD_CONTENT, 3);
+
+        assertThat(readChunked(chunkedStream, TestingChunkSigningSession.build(GOOD_CREDENTIAL, GOOD_SEED))).isEqualTo(GOOD_CONTENT.getBytes(UTF_8));
+    }
+
+    @Test
+    public void testBadSeed()
+    {
+        TestingChunkSigningSession signingSession = TestingChunkSigningSession.build(GOOD_CREDENTIAL, GOOD_SEED);
+        String chunkedStream = signingSession.generateChunkedStream(GOOD_CONTENT, 3);
+
+        assertThatThrownBy(() -> readChunked(chunkedStream, TestingChunkSigningSession.build(GOOD_CREDENTIAL, BAD_SEED)))
+                .isInstanceOf(WebApplicationException.class);
+    }
+
+    @Test
+    public void testBadCredential()
+    {
+        TestingChunkSigningSession signingSession = TestingChunkSigningSession.build(GOOD_CREDENTIAL, GOOD_SEED);
+        String chunkedStream = signingSession.generateChunkedStream(GOOD_CONTENT, 3);
+
+        assertThatThrownBy(() -> readChunked(chunkedStream, TestingChunkSigningSession.build(BAD_CREDENTIAL, BAD_SEED)))
+                .isInstanceOf(WebApplicationException.class);
+    }
+
+    @Test
+    public void testMultipleExtensions()
+            throws IOException
+    {
+        TestingChunkSigningSession signingSession = TestingChunkSigningSession.build(GOOD_CREDENTIAL, GOOD_SEED);
+        String chunkedStream = signingSession.generateChunkedStream(GOOD_CONTENT, 3);
+        chunkedStream = chunkedStream.replace(";chunk-signature=", ";foo=bar;chunk-signature=");
+
+        assertThat(readChunked(chunkedStream, signingSession)).isEqualTo(GOOD_CONTENT.getBytes(UTF_8));
+    }
+
+    private byte[] readChunked(String chunkedStream, TestingChunkSigningSession signingSession)
+            throws IOException
+    {
+        try (InputStream in = new AwsChunkedInputStream(new ByteArrayInputStream(chunkedStream.getBytes(UTF_8)), signingSession)) {
+            return ByteStreams.toByteArray(in);
+        }
+    }
+
+    // NOTE: below vvvvvvv tests are modified from https://github.com/apache/httpcomponents-core/blob/e009a923eefe79cf3593efbb0c18a3525ae63669/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestChunkCoding.java
+
+    private static final String CHUNKED_INPUT
+            = "10;chunk-signature=0\r\n1234567890123456\r\n5;chunk-signature=0\r\n12345\r\n0;chunk-signature=0\r\n\r\n";
+
+    private static final String CHUNKED_RESULT
+            = "123456789012345612345";
+
+    @Test
+    public void testChunkedInputStreamLargeBuffer()
+            throws IOException
+    {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(CHUNKED_INPUT.getBytes(UTF_8));
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        byte[] buffer = new byte[300];
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int len;
+        while ((len = in.read(buffer)) > 0) {
+            out.write(buffer, 0, len);
+        }
+        assertEquals(-1, in.read(buffer));
+        assertEquals(-1, in.read(buffer));
+
+        in.close();
+
+        String result = out.toString(UTF_8);
+        assertEquals(CHUNKED_RESULT, result);
+    }
+
+    //Test for when buffer is smaller than chunk size.
+    @Test
+    public void testChunkedInputStreamSmallBuffer()
+            throws IOException
+    {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(CHUNKED_INPUT.getBytes(UTF_8));
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+
+        byte[] buffer = new byte[7];
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int len;
+        while ((len = in.read(buffer)) > 0) {
+            out.write(buffer, 0, len);
+        }
+        assertEquals(-1, in.read(buffer));
+        assertEquals(-1, in.read(buffer));
+
+        String result = out.toString(UTF_8);
+        assertEquals("123456789012345612345", result);
+    }
+
+    // One byte read
+    @Test
+    public void testChunkedInputStreamOneByteRead()
+            throws IOException
+    {
+        String s = "5;chunk-signature=0\r\n01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\n\r\n";
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        int ch;
+        int i = '0';
+        while ((ch = in.read()) != -1) {
+            assertEquals(i, ch);
+            i++;
+        }
+        assertEquals(-1, in.read());
+        assertEquals(-1, in.read());
+
+        in.close();
+    }
+
+    // Missing closing chunk
+    @Test
+    public void testChunkedInputStreamNoClosingChunk()
+    {
+        String s = "5;chunk-signature=0\r\n01234\r\n";
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        byte[] tmp = new byte[5];
+        // altered from original test. Our AwsChunkedInputStream is improved and throws when the final chunk is missing or bad
+        assertThrows(IOException.class, () -> in.read(tmp));
+    }
+
+    // Truncated stream (missing closing CRLF)
+    @Test
+    public void testCorruptChunkedInputStreamTruncatedCRLF()
+            throws IOException
+    {
+        // altered to add a few more bad stings
+        Stream.of("5;chunk-signature=0\r\n01234", ";chunk-signature=0\r\n01234\r\n", "5;chunk-signature=0\r\n012340;chunk-signature=0\r\n\r\n")
+                .forEach(s -> {
+                    ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
+                    InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+                    byte[] tmp = new byte[5];
+                    // altered from original test. Our AwsChunkedInputStream is improved and throws when the final chunk is missing or bad
+                    assertThrows(IOException.class, () -> in.read(tmp));
+                    try {
+                        in.close();
+                    }
+                    catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                });
+    }
+
+    @Test
+    public void testCorruptChunkedInputStreamMissingCRLF()
+            throws IOException
+    {
+        String s = "5;chunk-signature=0\r\n012345\r\n56789\r\n0;chunk-signature=0\r\n\r\n";
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        byte[] buffer = new byte[300];
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        assertThrows(IOException.class, () -> {
+            int len;
+            while ((len = in.read(buffer)) > 0) {
+                out.write(buffer, 0, len);
+            }
+        });
+        in.close();
+    }
+
+    // Missing LF
+    @Test
+    public void testCorruptChunkedInputStreamMissingLF()
+            throws IOException
+    {
+        String s = "5;chunk-signature=0\r01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\n\r\n";
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        assertThrows(IOException.class, in::read);
+        in.close();
+    }
+
+    // Invalid chunk size
+    @Test
+    public void testCorruptChunkedInputStreamInvalidSize()
+            throws IOException
+    {
+        String s = "whatever;chunk-signature=0\r\n01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\n\r\n";
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        assertThrows(IOException.class, in::read);
+        in.close();
+    }
+
+    // Negative chunk size
+    @Test
+    public void testCorruptChunkedInputStreamNegativeSize()
+            throws IOException
+    {
+        String s = "-5;chunk-signature=0\r\n01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\n\r\n";
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        assertThrows(IOException.class, in::read);
+        in.close();
+    }
+
+    // Truncated chunk
+    @Test
+    public void testCorruptChunkedInputStreamTruncatedChunk()
+            throws IOException
+    {
+        String s = "3;chunk-signature=0\r\n12";
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        byte[] buffer = new byte[300];
+        assertEquals(2, in.read(buffer));
+        assertThrows(IOException.class, () -> in.read(buffer));
+        in.close();
+    }
+
+    @Test
+    public void testCorruptChunkedInputStreamClose()
+            throws IOException
+    {
+        String s = "whatever;chunk-signature=0\r\n01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\n\r\n";
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
+        try (InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession())) {
+            assertThrows(IOException.class, in::read);
+        }
+    }
+
+    @Test
+    public void testEmptyChunkedInputStream()
+            throws IOException
+    {
+        String s = "0;chunk-signature=0\r\n\r\n";
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        byte[] buffer = new byte[300];
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int len;
+        while ((len = in.read(buffer)) > 0) {
+            out.write(buffer, 0, len);
+        }
+        assertEquals(0, out.size());
+        in.close();
+    }
+
+    // Test for when buffer is larger than chunk size
+    @Test
+    public void testHugeChunk()
+            throws IOException
+    {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream("499602D2;chunk-signature=0\r\n01234567".getBytes(UTF_8));
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (int i = 0; i < 8; ++i) {
+            out.write(in.read());
+        }
+
+        String result = out.toString(UTF_8);
+        assertEquals("01234567", result);
+    }
+
+    private static class DummyChunkSigningSession
+            implements ChunkSigningSession
+    {
+        @Override
+        public void startChunk(String expectedSignature)
+        {
+            // NOP
+        }
+
+        @Override
+        public void complete()
+        {
+            // NOP
+        }
+
+        @Override
+        public void write(byte b)
+        {
+            // NOP
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len)
+        {
+            // NOP
+        }
+    }
+}

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/signing/TestingChunkSigningSession.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/signing/TestingChunkSigningSession.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.aws.proxy.server.signing;
+
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import io.trino.aws.proxy.spi.credentials.Credential;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.signer.internal.Aws4SignerRequestParams;
+import software.amazon.awssdk.auth.signer.internal.chunkedencoding.AwsS3V4ChunkSigner;
+import software.amazon.awssdk.auth.signer.params.Aws4SignerParams;
+import software.amazon.awssdk.regions.Region;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+public class TestingChunkSigningSession
+        extends InternalChunkSigningSession
+{
+    private final String seed;
+    private final Instant instant;
+    private final byte[] signingKey;
+
+    public static TestingChunkSigningSession build()
+    {
+        Credential credential = new Credential(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        String seed = "0".repeat(AwsS3V4ChunkSigner.getSignatureLength());
+        return build(credential, seed);
+    }
+
+    public static TestingChunkSigningSession build(Credential credential, String seed)
+    {
+        AwsCredentials credentials = AwsBasicCredentials.create(credential.accessKey(), credential.secretKey());
+        Aws4SignerParams.Builder<?> builder = Aws4SignerParams.builder()
+                .awsCredentials(credentials)
+                .doubleUrlEncode(false)
+                .signingName("s3")
+                .signingRegion(Region.US_EAST_1);
+        byte[] signingKey = Signer.signingKey(credentials, new Aws4SignerRequestParams(builder.build()));
+
+        return new TestingChunkSigningSession(seed, Instant.now(), signingKey);
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    public String generateChunkedStream(String content, int partitions)
+    {
+        checkArgument(partitions > 1, "partitions must be greater than 1");
+
+        ChunkSigner chunkSigner = new ChunkSigner(instant, "/dummy", signingKey);
+        String previousSignature = seed;
+
+        StringBuilder chunkedStream = new StringBuilder();
+        int chunkSize = content.length() / partitions;
+        int index = 0;
+        while (index < content.length()) {
+            int thisLength = Math.min(chunkSize, content.length() - index);
+            String thisChunk = content.substring(index, index + thisLength);
+
+            Hasher hasher = Hashing.sha256().newHasher();
+            hasher.putString(thisChunk, UTF_8);
+            String thisSignature = chunkSigner.signChunk(hasher.hash(), previousSignature);
+            chunkedStream.append(Integer.toHexString(thisLength)).append(";chunk-signature=").append(thisSignature).append("\r\n");
+            chunkedStream.append(thisChunk).append("\r\n");
+            previousSignature = thisSignature;
+
+            index += thisLength;
+        }
+
+        String thisSignature = chunkSigner.signChunk(Hashing.sha256().newHasher().hash(), previousSignature);
+        chunkedStream.append("0;chunk-signature=").append(thisSignature).append("\r\n\r\n");
+
+        return chunkedStream.toString();
+    }
+
+    private TestingChunkSigningSession(String seed, Instant instant, byte[] signingKey)
+    {
+        super(new ChunkSigner(instant, "/dummy", signingKey), seed);
+
+        this.seed = requireNonNull(seed, "seed is null");
+        this.instant = requireNonNull(instant, "instant is null");
+        this.signingKey = requireNonNull(signingKey, "signingKey is null");
+    }
+}


### PR DESCRIPTION
Rewrite of `AwsChunkedInputStream` for simplicity/clarity
    
~~Added `ReadAheadInputStream` which buffers a portion of a delegate input stream which is assumed to be an `AwsChunkedInputStream`. The purpose of this is to catch an edge case with the final chunk. By the time the final chunk
signature is verified, the bytes of the chunk will already be sent to the remote server and, thus, it's too late to prevent it. By reading ahead, the final chunk will get validated before the bytes are sent to the remote.~~

When the end of a chunk is reached it reads the next chunk's header. This ensures we don't send the final bytes of a request before they've been validated against the signature. i.e. the final chunk's signature cannot be validated
until the final chunk has been read. But, without this change, the final chunk's bytes will already have been sent.
