### PR TITLE
Cleanup aws-chunked decoded-content-length handling

### DIFF
--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/signing/Signer.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/signing/Signer.java
@@ -135,20 +135,11 @@ final class Signer
                 .enableChunkedEncoding(enableChunkedEncoding);
         SdkHttpFullRequest.Builder requestBuilder = SdkHttpFullRequest.builder();
         if (enablePayloadSigning) {
-            maybeAmazonContentHash.ifPresent(contentHashHeader -> {
-                if (!contentHashHeader.startsWith("STREAMING-")) {
-                    // because we stream content without spooling we want to re-use the provided content hash
-                    // so that we don't have to calculate it to validate the incoming signature.
-                    // Stash the hash in the OVERRIDE_CONTENT_HASH so that aws4Signer can find it and
-                    // return it.
-                    requestBuilder.putHeader(OVERRIDE_CONTENT_HASH, contentHashHeader);
-                }
-            });
-        }
-        if (enableChunkedEncoding) {
-            // when chunked, the correct signature needs to reset the content length to the original decoded length
-            signingHeaders.getFirst("x-amz-decoded-content-length")
-                    .ifPresent(decodedContentLength -> requestBuilder.putHeader("content-length", decodedContentLength));
+            // because we stream content without spooling we want to re-use the provided content hash
+            // so that we don't have to calculate it to validate the incoming signature.
+            // Stash the hash in the OVERRIDE_CONTENT_HASH so that aws4Signer can find it and
+            // return it.
+            maybeAmazonContentHash.ifPresent(contentHashHeader -> requestBuilder.putHeader(OVERRIDE_CONTENT_HASH, contentHashHeader));
         }
         return internalSign(
                 (signingApi, requestToSign) -> {

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/signing/SigningHeaders.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/signing/SigningHeaders.java
@@ -28,7 +28,6 @@ import java.util.stream.Stream;
 final class SigningHeaders
 {
     private static final Set<String> IGNORED_HEADERS = ImmutableSet.of(
-            "x-amz-decoded-content-length",
             "x-amzn-trace-id",
             "expect",
             "accept-encoding",


### PR DESCRIPTION
The AWS Signer classes mutate the request and try to automatically compute values for fields like `content-length` 
if we allow the library to touch the payload of a request. Always returning the hash that was present in the inbound
request ensures the library will not change any other fields.
