### PR TITLE
Add more thorough tests for aws-chunked

### DIFF
--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/signing/InternalChunkSigningSession.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/signing/InternalChunkSigningSession.java
@@ -13,6 +13,7 @@
  */
 package io.trino.aws.proxy.server.signing;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import io.airlift.log.Logger;
@@ -28,7 +29,8 @@ class InternalChunkSigningSession
 {
     private static final Logger log = Logger.get(InternalChunkSigningSession.class);
 
-    private final ChunkSigner chunkSigner;
+    @VisibleForTesting
+    protected final ChunkSigner chunkSigner;
     private String previousSignature;
     private String expectedSignature;
     private Hasher hasher;

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/AbstractTestProxiedRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/AbstractTestProxiedRequests.java
@@ -13,6 +13,7 @@
  */
 package io.trino.aws.proxy.server;
 
+import io.trino.aws.proxy.server.testing.TestingUtil;
 import jakarta.annotation.PreDestroy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -25,13 +26,11 @@ import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
-import software.amazon.awssdk.services.s3.model.Delete;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListBucketsResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
-import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Object;
@@ -80,16 +79,7 @@ public abstract class AbstractTestProxiedRequests
     @AfterEach
     public void cleanupBuckets()
     {
-        remoteClient.listBuckets().buckets().forEach(bucket -> remoteClient.listObjectsV2Paginator(request -> request.bucket(bucket.name())).forEach(s3ObjectPage -> {
-            if (s3ObjectPage.contents().isEmpty()) {
-                return;
-            }
-            List<ObjectIdentifier> objectIdentifiers = s3ObjectPage.contents()
-                    .stream()
-                    .map(s3Object -> ObjectIdentifier.builder().key(s3Object.key()).build())
-                    .collect(toImmutableList());
-            remoteClient.deleteObjects(deleteRequest -> deleteRequest.bucket(bucket.name()).delete(Delete.builder().objects(objectIdentifiers).build()));
-        }));
+        TestingUtil.cleanupBuckets(remoteClient);
     }
 
     @Test

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/TestingUtil.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/TestingUtil.java
@@ -20,21 +20,30 @@ import io.trino.aws.proxy.spi.credentials.Credentials;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public final class TestingUtil
 {
@@ -77,5 +86,36 @@ public final class TestingUtil
                 .filter(file -> file.getName().startsWith(name))
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("Unable to find test jar: " + name));
+    }
+
+    public static String getFileFromStorage(S3Client storageClient, String bucketName, String key)
+            throws IOException
+    {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket(bucketName).key(key).build();
+        ByteArrayOutputStream readContents = new ByteArrayOutputStream();
+        storageClient.getObject(getObjectRequest).transferTo(readContents);
+        return readContents.toString();
+    }
+
+    public static void cleanupBuckets(S3Client storageClient)
+    {
+        storageClient.listBuckets().buckets().forEach(bucket -> storageClient.listObjectsV2Paginator(request -> request.bucket(bucket.name())).forEach(s3ObjectPage -> {
+            if (s3ObjectPage.contents().isEmpty()) {
+                return;
+            }
+            List<ObjectIdentifier> objectIdentifiers = s3ObjectPage.contents()
+                    .stream()
+                    .map(s3Object -> ObjectIdentifier.builder().key(s3Object.key()).build())
+                    .collect(toImmutableList());
+            storageClient.deleteObjects(deleteRequest -> deleteRequest.bucket(bucket.name()).delete(Delete.builder().objects(objectIdentifiers).build()));
+        }));
+    }
+
+    public static void assertFileNotInS3(S3Client storageClient, String bucket, String key)
+    {
+        assertThatExceptionOfType(S3Exception.class)
+                .isThrownBy(() -> getFileFromStorage(storageClient, bucket, key))
+                .extracting(S3Exception::statusCode)
+                .isEqualTo(404);
     }
 }


### PR DESCRIPTION
This enables us to add more thorough testing for #101 and to deal with the issues discussed in #105 (where it is possible for a chunk with invalid size to cause the proxy to skip signature verification)