### PR TITLE
Rename and move TrinoS3ProxyConfig to TrinoAwsProxyConfig

### DIFF
--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/TrinoAwsProxyConfig.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/TrinoAwsProxyConfig.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.aws.proxy.server.rest;
+package io.trino.aws.proxy.server;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/TrinoAwsProxyConfig.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/TrinoAwsProxyConfig.java
@@ -25,7 +25,7 @@ public class TrinoAwsProxyConfig
     private String s3Path = "/api/v1/s3Proxy/s3";
     private String stsPath = "/api/v1/s3Proxy/sts";
 
-    @Config("s3proxy.s3.hostname")
+    @Config("aws.proxy.s3.hostname")
     @ConfigDescription("Hostname to use for S3 REST operations, virtual-host style addressing is only supported if this is set")
     public TrinoAwsProxyConfig setS3HostName(String s3HostName)
     {
@@ -39,7 +39,7 @@ public class TrinoAwsProxyConfig
         return s3HostName;
     }
 
-    @Config("s3proxy.s3.path")
+    @Config("aws.proxy.s3.path")
     @ConfigDescription("URL Path for S3 operations, optional")
     public TrinoAwsProxyConfig setS3Path(String s3Path)
     {
@@ -53,7 +53,7 @@ public class TrinoAwsProxyConfig
         return s3Path;
     }
 
-    @Config("s3proxy.sts.path")
+    @Config("aws.proxy.sts.path")
     @ConfigDescription("URL Path for STS operations, optional")
     public TrinoAwsProxyConfig setStsPath(String stsPath)
     {

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/TrinoAwsProxyServerModule.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/TrinoAwsProxyServerModule.java
@@ -29,7 +29,6 @@ import io.trino.aws.proxy.server.remote.RemoteS3Facade;
 import io.trino.aws.proxy.server.remote.VirtualHostStyleRemoteS3Facade;
 import io.trino.aws.proxy.server.rest.RequestFilter;
 import io.trino.aws.proxy.server.rest.RequestLoggerController;
-import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.rest.TrinoS3ProxyClient;
 import io.trino.aws.proxy.server.rest.TrinoS3ProxyClient.ForProxyClient;
 import io.trino.aws.proxy.server.rest.TrinoS3Resource;

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/TrinoAwsProxyServerModule.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/TrinoAwsProxyServerModule.java
@@ -29,9 +29,9 @@ import io.trino.aws.proxy.server.remote.RemoteS3Facade;
 import io.trino.aws.proxy.server.remote.VirtualHostStyleRemoteS3Facade;
 import io.trino.aws.proxy.server.rest.RequestFilter;
 import io.trino.aws.proxy.server.rest.RequestLoggerController;
+import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.rest.TrinoS3ProxyClient;
 import io.trino.aws.proxy.server.rest.TrinoS3ProxyClient.ForProxyClient;
-import io.trino.aws.proxy.server.rest.TrinoS3ProxyConfig;
 import io.trino.aws.proxy.server.rest.TrinoS3Resource;
 import io.trino.aws.proxy.server.rest.TrinoStsResource;
 import io.trino.aws.proxy.server.security.S3SecurityController;
@@ -67,7 +67,7 @@ public class TrinoAwsProxyServerModule
     protected void setup(Binder binder)
     {
         configBinder(binder).bindConfig(SigningControllerConfig.class);
-        TrinoS3ProxyConfig builtConfig = buildConfigObject(TrinoS3ProxyConfig.class);
+        TrinoAwsProxyConfig builtConfig = buildConfigObject(TrinoAwsProxyConfig.class);
 
         JaxrsBinder jaxrsBinder = jaxrsBinder(binder);
 

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoAwsProxyConfig.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoAwsProxyConfig.java
@@ -19,7 +19,7 @@ import jakarta.validation.constraints.NotNull;
 
 import java.util.Optional;
 
-public class TrinoS3ProxyConfig
+public class TrinoAwsProxyConfig
 {
     private Optional<String> s3HostName = Optional.empty();
     private String s3Path = "/api/v1/s3Proxy/s3";
@@ -27,7 +27,7 @@ public class TrinoS3ProxyConfig
 
     @Config("s3proxy.s3.hostname")
     @ConfigDescription("Hostname to use for S3 REST operations, virtual-host style addressing is only supported if this is set")
-    public TrinoS3ProxyConfig setS3HostName(String s3HostName)
+    public TrinoAwsProxyConfig setS3HostName(String s3HostName)
     {
         this.s3HostName = Optional.ofNullable(s3HostName);
         return this;
@@ -41,7 +41,7 @@ public class TrinoS3ProxyConfig
 
     @Config("s3proxy.s3.path")
     @ConfigDescription("URL Path for S3 operations, optional")
-    public TrinoS3ProxyConfig setS3Path(String s3Path)
+    public TrinoAwsProxyConfig setS3Path(String s3Path)
     {
         this.s3Path = s3Path;
         return this;
@@ -55,7 +55,7 @@ public class TrinoS3ProxyConfig
 
     @Config("s3proxy.sts.path")
     @ConfigDescription("URL Path for STS operations, optional")
-    public TrinoS3ProxyConfig setStsPath(String stsPath)
+    public TrinoAwsProxyConfig setStsPath(String stsPath)
     {
         this.stsPath = stsPath;
         return this;

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoS3Resource.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoS3Resource.java
@@ -41,7 +41,7 @@ public class TrinoS3Resource
     private final String s3Path;
 
     @Inject
-    public TrinoS3Resource(TrinoS3ProxyClient proxyClient, TrinoS3ProxyConfig trinoS3ProxyConfig)
+    public TrinoS3Resource(TrinoS3ProxyClient proxyClient, TrinoAwsProxyConfig trinoS3ProxyConfig)
     {
         this.proxyClient = requireNonNull(proxyClient, "proxyClient is null");
         this.serverHostName = trinoS3ProxyConfig.getS3HostName();

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoS3Resource.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoS3Resource.java
@@ -14,6 +14,7 @@
 package io.trino.aws.proxy.server.rest;
 
 import com.google.inject.Inject;
+import io.trino.aws.proxy.server.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.spi.rest.ParsedS3Request;
 import io.trino.aws.proxy.spi.rest.Request;
 import io.trino.aws.proxy.spi.signing.SigningMetadata;

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/AbstractTestStsRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/AbstractTestStsRequests.java
@@ -14,7 +14,6 @@
 package io.trino.aws.proxy.server;
 
 import io.airlift.http.server.testing.TestingHttpServer;
-import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.spi.credentials.Credential;
 import io.trino.aws.proxy.spi.credentials.Credentials;
 import io.trino.aws.proxy.spi.credentials.CredentialsProvider;

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/AbstractTestStsRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/AbstractTestStsRequests.java
@@ -14,7 +14,7 @@
 package io.trino.aws.proxy.server;
 
 import io.airlift.http.server.testing.TestingHttpServer;
-import io.trino.aws.proxy.server.rest.TrinoS3ProxyConfig;
+import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.spi.credentials.Credential;
 import io.trino.aws.proxy.spi.credentials.Credentials;
 import io.trino.aws.proxy.spi.credentials.CredentialsProvider;
@@ -38,7 +38,7 @@ public abstract class AbstractTestStsRequests
     private final StsClient stsClient;
     private final CredentialsProvider credentialsProvider;
 
-    public AbstractTestStsRequests(Credentials testingCredentials, TestingHttpServer httpServer, CredentialsProvider credentialsProvider, TrinoS3ProxyConfig s3ProxyConfig)
+    public AbstractTestStsRequests(Credentials testingCredentials, TestingHttpServer httpServer, CredentialsProvider credentialsProvider, TrinoAwsProxyConfig s3ProxyConfig)
     {
         this.credentialsProvider = requireNonNull(credentialsProvider, "credentialsProvider is null");
 

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/LocalServer.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/LocalServer.java
@@ -16,7 +16,7 @@ package io.trino.aws.proxy.server;
 import com.google.inject.Key;
 import io.airlift.http.server.testing.TestingHttpServer;
 import io.airlift.log.Logger;
-import io.trino.aws.proxy.server.rest.TrinoS3ProxyConfig;
+import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingTrinoAwsProxyServer;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;
 import io.trino.aws.proxy.spi.credentials.Credentials;
@@ -40,7 +40,7 @@ public final class LocalServer
 
         TestingHttpServer httpServer = trinoS3ProxyServer.getInjector().getInstance(TestingHttpServer.class);
         Credentials testingCredentials = trinoS3ProxyServer.getInjector().getInstance(Key.get(Credentials.class, ForTesting.class));
-        TrinoS3ProxyConfig s3ProxyConfig = trinoS3ProxyServer.getInjector().getInstance(TrinoS3ProxyConfig.class);
+        TrinoAwsProxyConfig s3ProxyConfig = trinoS3ProxyServer.getInjector().getInstance(TrinoAwsProxyConfig.class);
 
         log.info("");
         log.info("Endpoint:   %s", httpServer.getBaseUrl().resolve(s3ProxyConfig.getS3Path()));

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/LocalServer.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/LocalServer.java
@@ -16,7 +16,6 @@ package io.trino.aws.proxy.server;
 import com.google.inject.Key;
 import io.airlift.http.server.testing.TestingHttpServer;
 import io.airlift.log.Logger;
-import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingTrinoAwsProxyServer;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;
 import io.trino.aws.proxy.spi.credentials.Credentials;

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestGenericRestRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestGenericRestRequests.java
@@ -22,7 +22,7 @@ import io.airlift.http.server.testing.TestingHttpServer;
 import io.airlift.units.Duration;
 import io.trino.aws.proxy.server.credentials.CredentialsController;
 import io.trino.aws.proxy.server.rest.RequestLoggerController;
-import io.trino.aws.proxy.server.rest.TrinoS3ProxyConfig;
+import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.signing.InternalSigningController;
 import io.trino.aws.proxy.server.signing.SigningControllerConfig;
 import io.trino.aws.proxy.server.signing.TestingChunkSigningSession;
@@ -101,9 +101,9 @@ public class TestGenericRestRequests
             @ForTesting HttpClient httpClient,
             @ForTesting Credentials testingCredentials,
             @ForS3Container S3Client storageClient,
-            TrinoS3ProxyConfig trinoS3ProxyConfig)
+            TrinoAwsProxyConfig trinoAwsProxyConfig)
     {
-        baseUri = httpServer.getBaseUrl().resolve(trinoS3ProxyConfig.getS3Path());
+        baseUri = httpServer.getBaseUrl().resolve(trinoAwsProxyConfig.getS3Path());
         this.credentialsRolesProvider = requireNonNull(credentialsRolesProvider, "credentialsRolesProvider is null");
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.testingCredentials = requireNonNull(testingCredentials, "testingCredentials is null");

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestGenericRestRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestGenericRestRequests.java
@@ -22,7 +22,6 @@ import io.airlift.http.server.testing.TestingHttpServer;
 import io.airlift.units.Duration;
 import io.trino.aws.proxy.server.credentials.CredentialsController;
 import io.trino.aws.proxy.server.rest.RequestLoggerController;
-import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.signing.InternalSigningController;
 import io.trino.aws.proxy.server.signing.SigningControllerConfig;
 import io.trino.aws.proxy.server.signing.TestingChunkSigningSession;

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestPresignedRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestPresignedRequests.java
@@ -24,7 +24,7 @@ import io.airlift.http.client.StaticBodyGenerator;
 import io.airlift.http.client.StatusResponseHandler.StatusResponse;
 import io.airlift.http.client.StringResponseHandler.StringResponse;
 import io.airlift.http.server.testing.TestingHttpServer;
-import io.trino.aws.proxy.server.rest.TrinoS3ProxyConfig;
+import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingUtil;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;
 import io.trino.aws.proxy.server.testing.containers.S3Container.ForS3Container;
@@ -98,7 +98,7 @@ public class TestPresignedRequests
             @ForS3Container S3Client storageClient,
             @ForTesting Credentials testingCredentials,
             TestingHttpServer httpServer,
-            TrinoS3ProxyConfig s3ProxyConfig,
+            TrinoAwsProxyConfig s3ProxyConfig,
             XmlMapper xmlMapper)
     {
         this.httpClient = requireNonNull(httpClient, "httpClient is null");

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestPresignedRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestPresignedRequests.java
@@ -24,7 +24,6 @@ import io.airlift.http.client.StaticBodyGenerator;
 import io.airlift.http.client.StatusResponseHandler.StatusResponse;
 import io.airlift.http.client.StringResponseHandler.StringResponse;
 import io.airlift.http.server.testing.TestingHttpServer;
-import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingUtil;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;
 import io.trino.aws.proxy.server.testing.containers.S3Container.ForS3Container;

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestProxiedAssumedRoleRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestProxiedAssumedRoleRequests.java
@@ -15,7 +15,6 @@ package io.trino.aws.proxy.server;
 
 import com.google.inject.Inject;
 import io.airlift.http.server.testing.TestingHttpServer;
-import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingCredentialsRolesProvider;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;
 import io.trino.aws.proxy.server.testing.containers.S3Container.ForS3Container;

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestProxiedAssumedRoleRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestProxiedAssumedRoleRequests.java
@@ -15,7 +15,7 @@ package io.trino.aws.proxy.server;
 
 import com.google.inject.Inject;
 import io.airlift.http.server.testing.TestingHttpServer;
-import io.trino.aws.proxy.server.rest.TrinoS3ProxyConfig;
+import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingCredentialsRolesProvider;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;
 import io.trino.aws.proxy.server.testing.containers.S3Container.ForS3Container;
@@ -52,9 +52,9 @@ public class TestProxiedAssumedRoleRequests
             TestingCredentialsRolesProvider credentialsController,
             @ForS3Container S3Client storageClient,
             @ForS3Container List<String> configuredBuckets,
-            TrinoS3ProxyConfig trinoS3ProxyConfig)
+            TrinoAwsProxyConfig trinoAwsProxyConfig)
     {
-        this(buildClient(httpServer, testingCredentials, trinoS3ProxyConfig.getS3Path(), trinoS3ProxyConfig.getStsPath()), testingCredentials, credentialsController, storageClient, configuredBuckets);
+        this(buildClient(httpServer, testingCredentials, trinoAwsProxyConfig.getS3Path(), trinoAwsProxyConfig.getStsPath()), testingCredentials, credentialsController, storageClient, configuredBuckets);
     }
 
     protected TestProxiedAssumedRoleRequests(

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestProxiedEmulatedAndRemoteAssumedRoleRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestProxiedEmulatedAndRemoteAssumedRoleRequests.java
@@ -15,7 +15,7 @@ package io.trino.aws.proxy.server;
 
 import com.google.inject.Inject;
 import io.airlift.http.server.testing.TestingHttpServer;
-import io.trino.aws.proxy.server.rest.TrinoS3ProxyConfig;
+import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingCredentialsRolesProvider;
 import io.trino.aws.proxy.server.testing.TestingTrinoAwsProxyServerModule.ForTestingRemoteCredentials;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;
@@ -36,8 +36,8 @@ public class TestProxiedEmulatedAndRemoteAssumedRoleRequests
             @ForS3Container S3Client storageClient,
             @ForS3Container List<String> configuredBuckets,
             @ForTestingRemoteCredentials Credentials remoteCredentials,
-            TrinoS3ProxyConfig trinoS3ProxyConfig)
+            TrinoAwsProxyConfig trinoAwsProxyConfig)
     {
-        super(buildClient(httpServer, remoteCredentials, trinoS3ProxyConfig.getS3Path(), trinoS3ProxyConfig.getStsPath()), testingCredentials, credentialsController, storageClient, configuredBuckets);
+        super(buildClient(httpServer, remoteCredentials, trinoAwsProxyConfig.getS3Path(), trinoAwsProxyConfig.getStsPath()), testingCredentials, credentialsController, storageClient, configuredBuckets);
     }
 }

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestProxiedEmulatedAndRemoteAssumedRoleRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestProxiedEmulatedAndRemoteAssumedRoleRequests.java
@@ -15,7 +15,6 @@ package io.trino.aws.proxy.server;
 
 import com.google.inject.Inject;
 import io.airlift.http.server.testing.TestingHttpServer;
-import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingCredentialsRolesProvider;
 import io.trino.aws.proxy.server.testing.TestingTrinoAwsProxyServerModule.ForTestingRemoteCredentials;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestProxiedRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestProxiedRequests.java
@@ -33,7 +33,7 @@ public class TestProxiedRequests
         @Override
         public TestingTrinoAwsProxyServer.Builder filter(TestingTrinoAwsProxyServer.Builder builder)
         {
-            return builder.withProperty("s3proxy.s3.path", "/api/some/s3/path");
+            return builder.withProperty("aws.proxy.s3.path", "/api/some/s3/path");
         }
     }
 

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestProxiedRequestsWithEmptyPath.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestProxiedRequestsWithEmptyPath.java
@@ -33,7 +33,7 @@ public class TestProxiedRequestsWithEmptyPath
         @Override
         public TestingTrinoAwsProxyServer.Builder filter(TestingTrinoAwsProxyServer.Builder builder)
         {
-            return builder.withProperty("s3proxy.s3.path", "");
+            return builder.withProperty("aws.proxy.s3.path", "");
         }
     }
 

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestRemoteSessionProxiedRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestRemoteSessionProxiedRequests.java
@@ -15,7 +15,7 @@ package io.trino.aws.proxy.server;
 
 import com.google.inject.Inject;
 import io.airlift.http.server.testing.TestingHttpServer;
-import io.trino.aws.proxy.server.rest.TrinoS3ProxyConfig;
+import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingTrinoAwsProxyServerModule.ForTestingRemoteCredentials;
 import io.trino.aws.proxy.server.testing.containers.S3Container.ForS3Container;
 import io.trino.aws.proxy.server.testing.harness.TrinoAwsProxyTest;
@@ -34,9 +34,9 @@ public class TestRemoteSessionProxiedRequests
         extends AbstractTestProxiedRequests
 {
     @Inject
-    public TestRemoteSessionProxiedRequests(@ForS3Container S3Client storageClient, @ForTestingRemoteCredentials Credentials remoteCredentials, TestingHttpServer httpServer, @ForS3Container List<String> configuredBuckets, TrinoS3ProxyConfig trinoS3ProxyConfig)
+    public TestRemoteSessionProxiedRequests(@ForS3Container S3Client storageClient, @ForTestingRemoteCredentials Credentials remoteCredentials, TestingHttpServer httpServer, @ForS3Container List<String> configuredBuckets, TrinoAwsProxyConfig trinoAwsProxyConfig)
     {
-        super(buildInternalClient(remoteCredentials, httpServer, trinoS3ProxyConfig.getS3Path()), storageClient, configuredBuckets);
+        super(buildInternalClient(remoteCredentials, httpServer, trinoAwsProxyConfig.getS3Path()), storageClient, configuredBuckets);
     }
 
     private static S3Client buildInternalClient(Credentials credentials, TestingHttpServer httpServer, String s3Path)

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestRemoteSessionProxiedRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestRemoteSessionProxiedRequests.java
@@ -15,7 +15,6 @@ package io.trino.aws.proxy.server;
 
 import com.google.inject.Inject;
 import io.airlift.http.server.testing.TestingHttpServer;
-import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingTrinoAwsProxyServerModule.ForTestingRemoteCredentials;
 import io.trino.aws.proxy.server.testing.containers.S3Container.ForS3Container;
 import io.trino.aws.proxy.server.testing.harness.TrinoAwsProxyTest;

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestStsRequestsWithEmptyPath.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestStsRequestsWithEmptyPath.java
@@ -15,7 +15,7 @@ package io.trino.aws.proxy.server;
 
 import com.google.inject.Inject;
 import io.airlift.http.server.testing.TestingHttpServer;
-import io.trino.aws.proxy.server.rest.TrinoS3ProxyConfig;
+import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingTrinoAwsProxyServer;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;
 import io.trino.aws.proxy.server.testing.harness.BuilderFilter;
@@ -38,7 +38,7 @@ public class TestStsRequestsWithEmptyPath
     }
 
     @Inject
-    public TestStsRequestsWithEmptyPath(@ForTesting Credentials testingCredentials, TestingHttpServer httpServer, CredentialsProvider credentialsProvider, TrinoS3ProxyConfig s3ProxyConfig)
+    public TestStsRequestsWithEmptyPath(@ForTesting Credentials testingCredentials, TestingHttpServer httpServer, CredentialsProvider credentialsProvider, TrinoAwsProxyConfig s3ProxyConfig)
     {
         super(testingCredentials, httpServer, credentialsProvider, s3ProxyConfig);
     }

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestStsRequestsWithEmptyPath.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestStsRequestsWithEmptyPath.java
@@ -15,7 +15,6 @@ package io.trino.aws.proxy.server;
 
 import com.google.inject.Inject;
 import io.airlift.http.server.testing.TestingHttpServer;
-import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingTrinoAwsProxyServer;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;
 import io.trino.aws.proxy.server.testing.harness.BuilderFilter;

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestStsRequestsWithEmptyPath.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestStsRequestsWithEmptyPath.java
@@ -32,7 +32,7 @@ public class TestStsRequestsWithEmptyPath
         @Override
         public TestingTrinoAwsProxyServer.Builder filter(TestingTrinoAwsProxyServer.Builder builder)
         {
-            return builder.withProperty("s3proxy.sts.path", "");
+            return builder.withProperty("aws.proxy.sts.path", "");
         }
     }
 

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestStsRequestsWithPath.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestStsRequestsWithPath.java
@@ -15,7 +15,6 @@ package io.trino.aws.proxy.server;
 
 import com.google.inject.Inject;
 import io.airlift.http.server.testing.TestingHttpServer;
-import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingTrinoAwsProxyServer;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;
 import io.trino.aws.proxy.server.testing.harness.BuilderFilter;

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestStsRequestsWithPath.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestStsRequestsWithPath.java
@@ -32,7 +32,7 @@ public class TestStsRequestsWithPath
         @Override
         public TestingTrinoAwsProxyServer.Builder filter(TestingTrinoAwsProxyServer.Builder builder)
         {
-            return builder.withProperty("s3proxy.sts.path", "/api/some/sts/path");
+            return builder.withProperty("aws.proxy.sts.path", "/api/some/sts/path");
         }
     }
 

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestStsRequestsWithPath.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestStsRequestsWithPath.java
@@ -15,7 +15,7 @@ package io.trino.aws.proxy.server;
 
 import com.google.inject.Inject;
 import io.airlift.http.server.testing.TestingHttpServer;
-import io.trino.aws.proxy.server.rest.TrinoS3ProxyConfig;
+import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingTrinoAwsProxyServer;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;
 import io.trino.aws.proxy.server.testing.harness.BuilderFilter;
@@ -38,7 +38,7 @@ public class TestStsRequestsWithPath
     }
 
     @Inject
-    public TestStsRequestsWithPath(@ForTesting Credentials testingCredentials, TestingHttpServer httpServer, CredentialsProvider credentialsProvider, TrinoS3ProxyConfig s3ProxyConfig)
+    public TestStsRequestsWithPath(@ForTesting Credentials testingCredentials, TestingHttpServer httpServer, CredentialsProvider credentialsProvider, TrinoAwsProxyConfig s3ProxyConfig)
     {
         super(testingCredentials, httpServer, credentialsProvider, s3ProxyConfig);
     }

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/credentials/TestAssumingRoles.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/credentials/TestAssumingRoles.java
@@ -15,7 +15,7 @@ package io.trino.aws.proxy.server.credentials;
 
 import com.google.inject.Inject;
 import io.airlift.http.server.testing.TestingHttpServer;
-import io.trino.aws.proxy.server.rest.TrinoS3ProxyConfig;
+import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingCredentialsRolesProvider;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;
 import io.trino.aws.proxy.server.testing.harness.TrinoAwsProxyTest;
@@ -47,7 +47,7 @@ public class TestAssumingRoles
     private final Credentials testingCredentials;
 
     @Inject
-    public TestAssumingRoles(TestingCredentialsRolesProvider credentialsController, TestingHttpServer httpServer, @ForTesting Credentials testingCredentials, TrinoS3ProxyConfig trinoS3ProxyConfig)
+    public TestAssumingRoles(TestingCredentialsRolesProvider credentialsController, TestingHttpServer httpServer, @ForTesting Credentials testingCredentials, TrinoAwsProxyConfig trinoS3ProxyConfig)
     {
         this.credentialsController = requireNonNull(credentialsController, "credentialsController is null");
         this.testingCredentials = requireNonNull(testingCredentials, "testingCredentials is null");

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/credentials/TestAssumingRoles.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/credentials/TestAssumingRoles.java
@@ -15,7 +15,7 @@ package io.trino.aws.proxy.server.credentials;
 
 import com.google.inject.Inject;
 import io.airlift.http.server.testing.TestingHttpServer;
-import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
+import io.trino.aws.proxy.server.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingCredentialsRolesProvider;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;
 import io.trino.aws.proxy.server.testing.harness.TrinoAwsProxyTest;

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/TestingS3ClientProvider.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/TestingS3ClientProvider.java
@@ -16,7 +16,7 @@ package io.trino.aws.proxy.server.testing;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import io.airlift.http.server.testing.TestingHttpServer;
-import io.trino.aws.proxy.server.rest.TrinoS3ProxyConfig;
+import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;
 import io.trino.aws.proxy.spi.credentials.Credential;
 import io.trino.aws.proxy.spi.credentials.Credentials;
@@ -46,7 +46,7 @@ public class TestingS3ClientProvider
         }
 
         @Inject
-        public TestingS3ClientConfig(TrinoS3ProxyConfig config)
+        public TestingS3ClientConfig(TrinoAwsProxyConfig config)
         {
             this(config.getS3HostName(), config.getS3Path());
         }

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/TestingS3ClientProvider.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/TestingS3ClientProvider.java
@@ -16,7 +16,7 @@ package io.trino.aws.proxy.server.testing;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import io.airlift.http.server.testing.TestingHttpServer;
-import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
+import io.trino.aws.proxy.server.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;
 import io.trino.aws.proxy.spi.credentials.Credential;
 import io.trino.aws.proxy.spi.credentials.Credentials;

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/TestingTrinoAwsProxyServer.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/TestingTrinoAwsProxyServer.java
@@ -164,7 +164,7 @@ public final class TestingTrinoAwsProxyServer
 
         public Builder withServerHostName(String serverHostName)
         {
-            properties.put("s3proxy.hostname", serverHostName);
+            properties.put("aws.proxy.hostname", serverHostName);
             return this;
         }
 

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/containers/MetastoreContainer.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/containers/MetastoreContainer.java
@@ -17,7 +17,7 @@ import com.google.common.io.Resources;
 import com.google.inject.Inject;
 import io.airlift.http.server.testing.TestingHttpServer;
 import io.airlift.log.Logger;
-import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
+import io.trino.aws.proxy.server.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingUtil;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;
 import io.trino.aws.proxy.spi.credentials.Credentials;

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/containers/MetastoreContainer.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/containers/MetastoreContainer.java
@@ -17,7 +17,7 @@ import com.google.common.io.Resources;
 import com.google.inject.Inject;
 import io.airlift.http.server.testing.TestingHttpServer;
 import io.airlift.log.Logger;
-import io.trino.aws.proxy.server.rest.TrinoS3ProxyConfig;
+import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingUtil;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;
 import io.trino.aws.proxy.spi.credentials.Credentials;
@@ -48,10 +48,10 @@ public class MetastoreContainer
 
     @SuppressWarnings("resource")
     @Inject
-    public MetastoreContainer(PostgresContainer postgresContainer, TestingHttpServer httpServer, @ForTesting Credentials testingCredentials, TrinoS3ProxyConfig trinoS3ProxyConfig)
+    public MetastoreContainer(PostgresContainer postgresContainer, TestingHttpServer httpServer, @ForTesting Credentials testingCredentials, TrinoAwsProxyConfig trinoAwsProxyConfig)
             throws IOException
     {
-        String s3Endpoint = asHostUrl(httpServer.getBaseUrl().resolve(trinoS3ProxyConfig.getS3Path()).toString());
+        String s3Endpoint = asHostUrl(httpServer.getBaseUrl().resolve(trinoAwsProxyConfig.getS3Path()).toString());
 
         File postgresJar = TestingUtil.findTestJar("postgres");
         File hadoopJar = TestingUtil.findTestJar("hadoop");

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/containers/PySparkContainer.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/containers/PySparkContainer.java
@@ -16,7 +16,7 @@ package io.trino.aws.proxy.server.testing.containers;
 import com.google.inject.Inject;
 import io.airlift.http.server.testing.TestingHttpServer;
 import io.airlift.log.Logger;
-import io.trino.aws.proxy.server.rest.TrinoS3ProxyConfig;
+import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingUtil;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;
 import io.trino.aws.proxy.spi.credentials.Credentials;
@@ -44,7 +44,7 @@ public class PySparkContainer
 
     @SuppressWarnings("resource")
     @Inject
-    public PySparkContainer(MetastoreContainer metastoreContainer, TestingHttpServer httpServer, @ForTesting Credentials testingCredentials, TrinoS3ProxyConfig trinoS3ProxyConfig)
+    public PySparkContainer(MetastoreContainer metastoreContainer, TestingHttpServer httpServer, @ForTesting Credentials testingCredentials, TrinoAwsProxyConfig trinoS3ProxyConfig)
             throws IOException
     {
         File hadoopJar = TestingUtil.findTestJar("hadoop");

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/containers/PySparkContainer.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/containers/PySparkContainer.java
@@ -16,7 +16,7 @@ package io.trino.aws.proxy.server.testing.containers;
 import com.google.inject.Inject;
 import io.airlift.http.server.testing.TestingHttpServer;
 import io.airlift.log.Logger;
-import io.trino.aws.proxy.server.rest.TrinoAwsProxyConfig;
+import io.trino.aws.proxy.server.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.testing.TestingUtil;
 import io.trino.aws.proxy.server.testing.TestingUtil.ForTesting;
 import io.trino.aws.proxy.spi.credentials.Credentials;

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/harness/TrinoAwsProxyTestCommonModules.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/harness/TrinoAwsProxyTestCommonModules.java
@@ -65,7 +65,7 @@ public final class TrinoAwsProxyTestCommonModules
         @Override
         public TestingTrinoAwsProxyServer.Builder filter(TestingTrinoAwsProxyServer.Builder builder)
         {
-            return builder.withProperty("s3proxy.s3.hostname", LOCALHOST_DOMAIN);
+            return builder.withProperty("aws.proxy.s3.hostname", LOCALHOST_DOMAIN);
         }
     }
 


### PR DESCRIPTION
Better reflect its usage

Note: no code changes. Just renaming/moving.