### PR TITLE
Added identity to Credentials

### DIFF
--- a/trino-aws-proxy-spi/src/main/java/io/trino/aws/proxy/spi/credentials/Credentials.java
+++ b/trino-aws-proxy-spi/src/main/java/io/trino/aws/proxy/spi/credentials/Credentials.java
@@ -19,13 +19,14 @@ import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
-public record Credentials(Credential emulated, Optional<Credential> remote, Optional<RemoteSessionRole> remoteSessionRole)
+public record Credentials(Credential emulated, Optional<Credential> remote, Optional<RemoteSessionRole> remoteSessionRole, Optional<Identity> identity)
 {
     public Credentials
     {
         requireNonNull(emulated, "emulated is null");
         requireNonNull(remote, "remote is null");
         requireNonNull(remoteSessionRole, "remoteSessionRole is null");
+        requireNonNull(identity, "identity is null");
     }
 
     public Credential requiredRemoteCredential()
@@ -35,21 +36,21 @@ public record Credentials(Credential emulated, Optional<Credential> remote, Opti
 
     public static Credentials build(Credential emulated)
     {
-        return new Credentials(emulated, Optional.empty(), Optional.empty());
+        return new Credentials(emulated, Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     public static Credentials build(Credential emulated, Credential remote)
     {
-        return new Credentials(emulated, Optional.of(remote), Optional.empty());
+        return new Credentials(emulated, Optional.of(remote), Optional.empty(), Optional.empty());
     }
 
     public static Credentials build(Credential emulated, Optional<Credential> remote)
     {
-        return new Credentials(emulated, remote, Optional.empty());
+        return new Credentials(emulated, remote, Optional.empty(), Optional.empty());
     }
 
     public static Credentials build(Credential emulated, Credential remote, RemoteSessionRole remoteSessionRole)
     {
-        return new Credentials(emulated, Optional.of(remote), Optional.of(remoteSessionRole));
+        return new Credentials(emulated, Optional.of(remote), Optional.of(remoteSessionRole), Optional.empty());
     }
 }

--- a/trino-aws-proxy-spi/src/main/java/io/trino/aws/proxy/spi/credentials/Identity.java
+++ b/trino-aws-proxy-spi/src/main/java/io/trino/aws/proxy/spi/credentials/Identity.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.aws.proxy.spi.credentials;
+
+public interface Identity
+{
+    String user();
+}

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/credentials/file/FileBasedCredentialsProviderModule.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/credentials/file/FileBasedCredentialsProviderModule.java
@@ -13,11 +13,15 @@
  */
 package io.trino.aws.proxy.server.credentials.file;
 
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.aws.proxy.spi.credentials.CredentialsProvider;
+import io.trino.aws.proxy.spi.credentials.Identity;
 
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class FileBasedCredentialsProviderModule
@@ -28,5 +32,11 @@ public class FileBasedCredentialsProviderModule
     {
         configBinder(binder).bindConfig(FileBasedCredentialsProviderConfig.class);
         binder.bind(CredentialsProvider.class).to(FileBasedCredentialsProvider.class).in(Scopes.SINGLETON);
+    }
+
+    public static void bindFileBasedCredentialsIdentity(Binder binder, Class<? extends Identity> type)
+    {
+        newSetBinder(binder, Module.class).addBinding()
+                .toInstance(new SimpleModule().addAbstractTypeMapping(Identity.class, type));
     }
 }

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestGenericRestRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestGenericRestRequests.java
@@ -200,7 +200,7 @@ public class TestGenericRestRequests
         storageClient.createBucket(r -> r.bucket("foo").build());
 
         Credential credential = new Credential("df4899b1-9026-4c51-a3f3-38fffa236748", "2a142f69-d384-4739-8733-2977f73e2d2c");
-        Credentials credentials = new Credentials(credential, testingCredentials.remote(), Optional.empty());
+        Credentials credentials = new Credentials(credential, testingCredentials.remote(), Optional.empty(), Optional.empty());
         credentialsRolesProvider.addCredentials(credentials);
 
         assertThat(doPutObject(goodContent, goodSha256).getStatusCode()).isEqualTo(200);

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/TestingIdentity.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/TestingIdentity.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.aws.proxy.server.testing;
+
+import io.trino.aws.proxy.spi.credentials.Identity;
+
+import static java.util.Objects.requireNonNull;
+
+public record TestingIdentity(String user)
+        implements Identity
+{
+    public TestingIdentity
+    {
+        requireNonNull(user, "username is null");
+    }
+
+    @Override
+    public String user()
+    {
+        return user;
+    }
+}

--- a/trino-aws-proxy/src/test/resources/credentials.json
+++ b/trino-aws-proxy/src/test/resources/credentials.json
@@ -7,6 +7,9 @@
     "remote": {
       "accessKey": "test-remote-access-key",
       "secretKey": "test-remote-secret"
+    },
+    "identity": {
+      "user": "test-username"
     }
   }
 ]


### PR DESCRIPTION
The Identity entity is modelled as an interface and embedded into the Credentials class. 
Ideally, teams implement their own version of Identity and provide custom deserialization logic.