### PR TITLE
Add strict signature validation of aws-chunked streams

### DIFF
--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoS3ProxyClient.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoS3ProxyClient.java
@@ -185,7 +185,7 @@ public class TrinoS3ProxyClient
     private Optional<InputStream> contentInputStream(RequestContent requestContent, SigningMetadata signingMetadata)
     {
         return switch (requestContent.contentType()) {
-            case AWS_CHUNKED -> requestContent.inputStream().map(inputStream -> new AwsChunkedInputStream(inputStream, signingMetadata.requiredSigningContext().chunkSigningSession()));
+            case AWS_CHUNKED -> requestContent.inputStream().map(inputStream -> new AwsChunkedInputStream(inputStream, signingMetadata.requiredSigningContext().chunkSigningSession(), requestContent.contentLength().orElseThrow()));
 
             case STANDARD, W3C_CHUNKED -> requestContent.inputStream().map(inputStream -> {
                 SigningContext signingContext = signingMetadata.requiredSigningContext();

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/rest/TestAwsChunkedInputStream.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/rest/TestAwsChunkedInputStream.java
@@ -13,15 +13,19 @@
  */
 package io.trino.aws.proxy.server.rest;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
 import io.trino.aws.proxy.server.signing.TestingChunkSigningSession;
 import io.trino.aws.proxy.spi.credentials.Credential;
 import io.trino.aws.proxy.spi.signing.ChunkSigningSession;
+import io.trino.aws.proxy.spi.util.AwsTimestamp;
 import jakarta.ws.rs.WebApplicationException;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.signer.internal.chunkedencoding.AwsS3V4ChunkSigner;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -41,32 +45,47 @@ public class TestAwsChunkedInputStream
 
     private static final Credential BAD_CREDENTIAL = new Credential("BAD_TEST_ACCESS_KEY", "BAD_TEST_SECRET_KEY");
     private static final String BAD_SEED = "THIS IS A FAKE BAD SEED";
+    private static final String ILLEGAL_CHUNK_SIGNATURE = "0".repeat(AwsS3V4ChunkSigner.getSignatureLength());
+
+    private interface ChunkReader
+    {
+        void read(String chunkedData, int decodedContentLength, TestingChunkSigningSession signingSession, ByteArrayOutputStream output)
+                throws IOException;
+    }
+
+    private static TestingChunkSigningSession goodTestSigningSession()
+    {
+        return TestingChunkSigningSession.build(GOOD_CREDENTIAL, GOOD_SEED);
+    }
+
+    private static TestingChunkSigningSession fixedTimeGoodTestSigningSession()
+    {
+        return TestingChunkSigningSession.build(GOOD_CREDENTIAL, GOOD_SEED, AwsTimestamp.fromRequestTimestamp("20240801T010203Z"));
+    }
 
     @Test
     public void testGood()
             throws IOException
     {
-        TestingChunkSigningSession signingSession = TestingChunkSigningSession.build(GOOD_CREDENTIAL, GOOD_SEED);
-        String chunkedStream = signingSession.generateChunkedStream(GOOD_CONTENT, 3);
+        TestingChunkSigningSession session = goodTestSigningSession();
+        String chunkedStream = session.generateChunkedStream(GOOD_CONTENT, 3);
 
-        assertThat(readChunked(chunkedStream, signingSession)).isEqualTo(GOOD_CONTENT.getBytes(UTF_8));
+        assertThat(readChunked(chunkedStream, session)).isEqualTo(GOOD_CONTENT.getBytes(UTF_8));
     }
 
     @Test
     public void testRecreateSessionValidatesGoodPayload()
             throws IOException
     {
-        TestingChunkSigningSession signingSession = TestingChunkSigningSession.build(GOOD_CREDENTIAL, GOOD_SEED);
-        String chunkedStream = signingSession.generateChunkedStream(GOOD_CONTENT, 3);
+        String chunkedStream = goodTestSigningSession().generateChunkedStream(GOOD_CONTENT, 3);
 
-        assertThat(readChunked(chunkedStream, TestingChunkSigningSession.build(GOOD_CREDENTIAL, GOOD_SEED))).isEqualTo(GOOD_CONTENT.getBytes(UTF_8));
+        assertThat(readChunked(chunkedStream, goodTestSigningSession())).isEqualTo(GOOD_CONTENT.getBytes(UTF_8));
     }
 
     @Test
     public void testBadSeed()
     {
-        TestingChunkSigningSession signingSession = TestingChunkSigningSession.build(GOOD_CREDENTIAL, GOOD_SEED);
-        String chunkedStream = signingSession.generateChunkedStream(GOOD_CONTENT, 3);
+        String chunkedStream = goodTestSigningSession().generateChunkedStream(GOOD_CONTENT, 3);
 
         assertThatThrownBy(() -> readChunked(chunkedStream, TestingChunkSigningSession.build(GOOD_CREDENTIAL, BAD_SEED)))
                 .isInstanceOf(WebApplicationException.class);
@@ -75,8 +94,7 @@ public class TestAwsChunkedInputStream
     @Test
     public void testBadCredential()
     {
-        TestingChunkSigningSession signingSession = TestingChunkSigningSession.build(GOOD_CREDENTIAL, GOOD_SEED);
-        String chunkedStream = signingSession.generateChunkedStream(GOOD_CONTENT, 3);
+        String chunkedStream = goodTestSigningSession().generateChunkedStream(GOOD_CONTENT, 3);
 
         assertThatThrownBy(() -> readChunked(chunkedStream, TestingChunkSigningSession.build(BAD_CREDENTIAL, BAD_SEED)))
                 .isInstanceOf(WebApplicationException.class);
@@ -86,17 +104,192 @@ public class TestAwsChunkedInputStream
     public void testMultipleExtensions()
             throws IOException
     {
-        TestingChunkSigningSession signingSession = TestingChunkSigningSession.build(GOOD_CREDENTIAL, GOOD_SEED);
-        String chunkedStream = signingSession.generateChunkedStream(GOOD_CONTENT, 3);
+        String chunkedStream = goodTestSigningSession().generateChunkedStream(GOOD_CONTENT, 3);
         chunkedStream = chunkedStream.replace(";chunk-signature=", ";foo=bar;chunk-signature=");
 
-        assertThat(readChunked(chunkedStream, signingSession)).isEqualTo(GOOD_CONTENT.getBytes(UTF_8));
+        assertThat(readChunked(chunkedStream, goodTestSigningSession())).isEqualTo(GOOD_CONTENT.getBytes(UTF_8));
     }
 
-    private byte[] readChunked(String chunkedStream, TestingChunkSigningSession signingSession)
+    @Test
+    public void testAwsChunkedCornerCases()
             throws IOException
     {
-        try (InputStream in = new AwsChunkedInputStream(new ByteArrayInputStream(chunkedStream.getBytes(UTF_8)), signingSession)) {
+        // Ensure that the input stream always validates the data prior to returning x-amz-decoded-content-length bytes
+        // Otherwise we could be skipping signature verification if a chunk reports a larger size than x-amz-decoded-content-length
+        // We need to ensure this is the case regardless of the amount of bytes we read at a time - which is controlled by Jetty
+        for (ChunkReader readerMethod : ImmutableList.of(
+                // Read 1 byte at a time using the read() method
+                TestAwsChunkedInputStream::tryReadAwsChunkedData,
+                // Read using the read(byte[], off, len) method
+                // Read 1 byte at a time
+                buildBatchedAwsChunkedReader(1),
+                // Read an even number of bytes
+                buildBatchedAwsChunkedReader(2),
+                // Read an odd number of bytes
+                buildBatchedAwsChunkedReader(3),
+                // Read a very large number of bytes
+                buildBatchedAwsChunkedReader(4096))) {
+            // Both chunks are the same size
+            testAwsChunkedCornerCases("abcdef", "ghijkl", readerMethod);
+            // Chunks are different sizes
+            testAwsChunkedCornerCases("abcdef", "ghi", readerMethod);
+            // Potential tricky case: the last chunk is a single byte (meaning a single read from the chunk should force signature verification)
+            testAwsChunkedCornerCases("abcdef", "g", readerMethod);
+        }
+    }
+
+    private void testAwsChunkedCornerCases(String firstChunkContent, String secondChunkContent, ChunkReader readMethod)
+            throws IOException
+    {
+        final int totalContentLength = firstChunkContent.length() + secondChunkContent.length();
+
+        String firstChunkSignature = fixedTimeGoodTestSigningSession().getChunkSignature(firstChunkContent, GOOD_SEED);
+        String secondChunkSignature = fixedTimeGoodTestSigningSession().getChunkSignature(secondChunkContent, firstChunkSignature);
+        String finalChunkSignature = fixedTimeGoodTestSigningSession().getChunkSignature("", secondChunkSignature);
+
+        String validFirstChunk = buildChunk(firstChunkContent.length(), firstChunkSignature, firstChunkContent);
+        String validSecondChunk = buildChunk(secondChunkContent.length(), secondChunkSignature, secondChunkContent);
+        String validFinalChunk = buildChunk(0, finalChunkSignature, "");
+
+        // Sanity check - the below should be read correctly
+        ByteArrayOutputStream testOutput = new ByteArrayOutputStream();
+        String correctChunkedData = String.join("", validFirstChunk, validSecondChunk, validFinalChunk);
+        readMethod.read(correctChunkedData, totalContentLength, fixedTimeGoodTestSigningSession(), testOutput);
+        assertThat(testOutput.toByteArray()).hasSize(totalContentLength);
+        assertThat(testOutput.toString(UTF_8)).isEqualTo(firstChunkContent + secondChunkContent);
+
+        // Data is correctly chunked, but the decoded content length is underreported
+        testIllegalAwsChunkedData(
+                correctChunkedData,
+                totalContentLength - 1,
+                fixedTimeGoodTestSigningSession(),
+                readMethod);
+        // Data is correctly chunked, but the decoded content length is overreported
+        testIllegalAwsChunkedData(
+                correctChunkedData,
+                totalContentLength + 1,
+                fixedTimeGoodTestSigningSession(),
+                readMethod);
+
+        // Missing final chunk
+        testIllegalAwsChunkedData(
+                String.join("", validFirstChunk, validSecondChunk),
+                totalContentLength,
+                fixedTimeGoodTestSigningSession(),
+                readMethod);
+
+        // First chunk has an invalid signature
+        testIllegalAwsChunkedData(
+                String.join("", buildChunk(firstChunkContent.length(), ILLEGAL_CHUNK_SIGNATURE, firstChunkContent), validSecondChunk, validFinalChunk),
+                totalContentLength,
+                fixedTimeGoodTestSigningSession(),
+                readMethod);
+        // Second chunk has an invalid signature
+        testIllegalAwsChunkedData(
+                String.join("", validFirstChunk, buildChunk(secondChunkContent.length(), ILLEGAL_CHUNK_SIGNATURE, secondChunkContent), validFinalChunk),
+                totalContentLength,
+                fixedTimeGoodTestSigningSession(),
+                readMethod);
+        // Final chunk has an invalid signature
+        testIllegalAwsChunkedData(
+                String.join("", validFirstChunk, validSecondChunk, buildChunk(0, ILLEGAL_CHUNK_SIGNATURE, "")),
+                totalContentLength,
+                fixedTimeGoodTestSigningSession(),
+                readMethod);
+
+        // First chunk overreports its size - total content length unchanged
+        testIllegalAwsChunkedData(
+                String.join("", buildChunk(firstChunkContent.length() + 1, firstChunkSignature, firstChunkContent), validSecondChunk, validFinalChunk),
+                totalContentLength,
+                fixedTimeGoodTestSigningSession(),
+                readMethod);
+        // First chunk overreports its size - total content length increased to match
+        testIllegalAwsChunkedData(
+                String.join("", buildChunk(firstChunkContent.length() + 1, firstChunkSignature, firstChunkContent), validSecondChunk, validFinalChunk),
+                totalContentLength + 1,
+                fixedTimeGoodTestSigningSession(),
+                readMethod);
+
+        // Second chunk overreports its size - total content length unchanged
+        testIllegalAwsChunkedData(
+                String.join("", validFirstChunk, buildChunk(secondChunkContent.length() + 1, secondChunkSignature, secondChunkContent), validFinalChunk),
+                totalContentLength,
+                fixedTimeGoodTestSigningSession(),
+                readMethod);
+        // Second chunk overreports its size - total content length increased to match
+        testIllegalAwsChunkedData(
+                String.join("", validFirstChunk, buildChunk(secondChunkContent.length() + 1, secondChunkSignature, secondChunkContent), validFinalChunk),
+                totalContentLength + 1,
+                fixedTimeGoodTestSigningSession(),
+                readMethod);
+
+        // Final chunk has invalid size - total content length unchanged
+        testIllegalAwsChunkedData(
+                String.join("", validFirstChunk, validSecondChunk, buildChunk(1, finalChunkSignature, "")),
+                totalContentLength,
+                fixedTimeGoodTestSigningSession(),
+                readMethod);
+        // Final chunk has invalid size - total content length increased to match
+        testIllegalAwsChunkedData(
+                String.join("", validFirstChunk, validSecondChunk, buildChunk(1, finalChunkSignature, "")),
+                totalContentLength + 1,
+                fixedTimeGoodTestSigningSession(),
+                readMethod);
+    }
+
+    private static String buildChunk(int reportedChunkSize, String chunkSignature, String chunkContent)
+    {
+        return "%s;chunk-signature=%s\r\n%s\r\n".formatted(Integer.toString(reportedChunkSize, 16), chunkSignature, chunkContent);
+    }
+
+    private static ChunkReader buildBatchedAwsChunkedReader(int bytesToReadAtATime)
+    {
+        return (chunkedData, decodedContentLength, signingSession, output) -> tryReadAwsChunkedDataBatch(chunkedData, decodedContentLength, signingSession, output, bytesToReadAtATime);
+    }
+
+    private static void tryReadAwsChunkedDataBatch(String chunkedData, int decodedContentLength, TestingChunkSigningSession signingSession, ByteArrayOutputStream output, int bytesToReadAtATime)
+            throws IOException
+    {
+        int remainingBytes = decodedContentLength;
+        try (InputStream in = new AwsChunkedInputStream(new ByteArrayInputStream(chunkedData.getBytes(UTF_8)), signingSession, decodedContentLength)) {
+            while (remainingBytes > 0) {
+                byte[] readBytes = new byte[bytesToReadAtATime];
+                int count = in.read(readBytes, 0, bytesToReadAtATime);
+                if (count < 0) {
+                    throw new EOFException("Unexpected EOF");
+                }
+                remainingBytes -= count;
+                output.write(readBytes, 0, count);
+            }
+        }
+    }
+
+    private static void tryReadAwsChunkedData(String chunkedData, int decodedContentLength, TestingChunkSigningSession signingSession, ByteArrayOutputStream output)
+            throws IOException
+    {
+        int remainingBytes = decodedContentLength;
+        try (InputStream in = new AwsChunkedInputStream(new ByteArrayInputStream(chunkedData.getBytes(UTF_8)), signingSession, decodedContentLength)) {
+            while (remainingBytes-- > 0) {
+                int readByte = in.read();
+                if (readByte == -1) {
+                    throw new EOFException("Unexpected EOF");
+                }
+                output.write(readByte);
+            }
+        }
+    }
+
+    private static void testIllegalAwsChunkedData(String chunkedData, int decodedContentLength, TestingChunkSigningSession signingSession, ChunkReader readerMethod)
+    {
+        ByteArrayOutputStream testOutput = new ByteArrayOutputStream();
+        assertThatThrownBy(() -> readerMethod.read(chunkedData, decodedContentLength, signingSession, testOutput)).isInstanceOfAny(IllegalStateException.class, WebApplicationException.class, IOException.class);
+        assertThat(testOutput.toByteArray().length).isLessThan(decodedContentLength);
+    }
+
+    private static byte[] readChunked(String chunkedStream, TestingChunkSigningSession signingSession)
+            throws IOException
+    {
+        try (InputStream in = new AwsChunkedInputStream(new ByteArrayInputStream(chunkedStream.getBytes(UTF_8)), signingSession, chunkedStream.length())) {
             return ByteStreams.toByteArray(in);
         }
     }
@@ -113,8 +306,9 @@ public class TestAwsChunkedInputStream
     public void testChunkedInputStreamLargeBuffer()
             throws IOException
     {
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(CHUNKED_INPUT.getBytes(UTF_8));
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        byte[] rawBytes = CHUNKED_INPUT.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
         byte[] buffer = new byte[300];
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         int len;
@@ -135,8 +329,9 @@ public class TestAwsChunkedInputStream
     public void testChunkedInputStreamSmallBuffer()
             throws IOException
     {
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(CHUNKED_INPUT.getBytes(UTF_8));
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        byte[] rawBytes = CHUNKED_INPUT.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
 
         byte[] buffer = new byte[7];
         ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -157,8 +352,9 @@ public class TestAwsChunkedInputStream
             throws IOException
     {
         String s = "5;chunk-signature=0\r\n01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\n\r\n";
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
         int ch;
         int i = '0';
         while ((ch = in.read()) != -1) {
@@ -176,8 +372,9 @@ public class TestAwsChunkedInputStream
     public void testChunkedInputStreamNoClosingChunk()
     {
         String s = "5;chunk-signature=0\r\n01234\r\n";
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
         byte[] tmp = new byte[5];
         // altered from original test. Our AwsChunkedInputStream is improved and throws when the final chunk is missing or bad
         assertThrows(IOException.class, () -> in.read(tmp));
@@ -191,8 +388,9 @@ public class TestAwsChunkedInputStream
         // altered to add a few more bad stings
         Stream.of("5;chunk-signature=0\r\n01234", ";chunk-signature=0\r\n01234\r\n", "5;chunk-signature=0\r\n012340;chunk-signature=0\r\n\r\n")
                 .forEach(s -> {
-                    ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
-                    InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+                    byte[] rawBytes = s.getBytes(UTF_8);
+                    ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+                    InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
                     byte[] tmp = new byte[5];
                     // altered from original test. Our AwsChunkedInputStream is improved and throws when the final chunk is missing or bad
                     assertThrows(IOException.class, () -> in.read(tmp));
@@ -210,8 +408,9 @@ public class TestAwsChunkedInputStream
             throws IOException
     {
         String s = "5;chunk-signature=0\r\n012345\r\n56789\r\n0;chunk-signature=0\r\n\r\n";
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
         byte[] buffer = new byte[300];
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         assertThrows(IOException.class, () -> {
@@ -229,8 +428,9 @@ public class TestAwsChunkedInputStream
             throws IOException
     {
         String s = "5;chunk-signature=0\r01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\n\r\n";
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
         assertThrows(IOException.class, in::read);
         in.close();
     }
@@ -241,8 +441,9 @@ public class TestAwsChunkedInputStream
             throws IOException
     {
         String s = "whatever;chunk-signature=0\r\n01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\n\r\n";
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
         assertThrows(IOException.class, in::read);
         in.close();
     }
@@ -253,8 +454,9 @@ public class TestAwsChunkedInputStream
             throws IOException
     {
         String s = "-5;chunk-signature=0\r\n01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\n\r\n";
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
         assertThrows(IOException.class, in::read);
         in.close();
     }
@@ -265,8 +467,9 @@ public class TestAwsChunkedInputStream
             throws IOException
     {
         String s = "3;chunk-signature=0\r\n12";
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
         byte[] buffer = new byte[300];
         assertEquals(2, in.read(buffer));
         assertThrows(IOException.class, () -> in.read(buffer));
@@ -278,8 +481,9 @@ public class TestAwsChunkedInputStream
             throws IOException
     {
         String s = "whatever;chunk-signature=0\r\n01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\n\r\n";
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
-        try (InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession())) {
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        try (InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length)) {
             assertThrows(IOException.class, in::read);
         }
     }
@@ -289,8 +493,9 @@ public class TestAwsChunkedInputStream
             throws IOException
     {
         String s = "0;chunk-signature=0\r\n\r\n";
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(UTF_8));
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
         byte[] buffer = new byte[300];
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         int len;
@@ -306,8 +511,9 @@ public class TestAwsChunkedInputStream
     public void testHugeChunk()
             throws IOException
     {
-        ByteArrayInputStream inputStream = new ByteArrayInputStream("499602D2;chunk-signature=0\r\n01234567".getBytes(UTF_8));
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession());
+        byte[] rawBytes = "499602D2;chunk-signature=0\r\n01234567".getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), 1234567890);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         for (int i = 0; i < 8; ++i) {

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/signing/TestingChunkSigningSession.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/signing/TestingChunkSigningSession.java
@@ -103,9 +103,7 @@ public class TestingChunkSigningSession
             int thisLength = Math.min(chunkSize, content.length() - index);
             String thisChunk = content.substring(index, index + thisLength);
 
-            Hasher hasher = Hashing.sha256().newHasher();
-            hasher.putString(thisChunk, UTF_8);
-            String thisSignature = chunkSigner.signChunk(hasher.hash(), previousSignature);
+            String thisSignature = getChunkSignature(thisChunk, previousSignature);
             chunkedStream.append(Integer.toHexString(thisLength)).append(";chunk-signature=").append(thisSignature).append("\r\n");
             chunkedStream.append(thisChunk).append("\r\n");
             previousSignature = thisSignature;
@@ -117,6 +115,14 @@ public class TestingChunkSigningSession
         chunkedStream.append("0;chunk-signature=").append(thisSignature).append("\r\n\r\n");
 
         return chunkedStream.toString();
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    public String getChunkSignature(String chunkContent, String previousSignature)
+    {
+        Hasher hasher = Hashing.sha256().newHasher();
+        hasher.putString(chunkContent, UTF_8);
+        return chunkSigner.signChunk(hasher.hash(), previousSignature);
     }
 
     private TestingChunkSigningSession(String seed, Instant instant, byte[] signingKey, String keyPath)

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/TestingUtil.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/TestingUtil.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -129,5 +130,10 @@ public final class TestingUtil
                 .isThrownBy(() -> getFileFromStorage(storageClient, bucket, key))
                 .extracting(S3Exception::statusCode)
                 .isEqualTo(404);
+    }
+
+    public static List<String> listFilesInS3Bucket(S3Client storageClient, String bucket)
+    {
+        return storageClient.listObjects(request -> request.bucket(bucket)).contents().stream().map(S3Object::key).collect(toImmutableList());
     }
 }


### PR DESCRIPTION
Closes #102

Ensure we never return `x-amz-decoded-content-length` bytes without having verified the signatures.

This should protect us from:
- Chunks overreporting their size so that we send `x-amz-decoded-content-length` before validating the signature (as the proxy did not know the chunk had finished)
- Chunks containing more data than they report
- Mismatched declared and actual content lengths