### PR TITLE
Improve tests for remote session credentials

### DIFF
--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/TestingCredentialsRolesProvider.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/TestingCredentialsRolesProvider.java
@@ -69,7 +69,9 @@ public class TestingCredentialsRolesProvider
                 checkState(emulatedAccessKey.equals(session.sessionCredential.accessKey()), "emulatedAccessKey and session accessKey mismatch");
 
                 Credentials originalCredentials = requireNonNull(credentials.get(session.originalEmulatedAccessKey), "original credentials missing for: " + session.originalEmulatedAccessKey);
-                return Optional.of(Credentials.build(session.sessionCredential, originalCredentials.remote()));
+                return Optional.of(originalCredentials.remoteSessionRole()
+                        .map(remoteSessionRole -> Credentials.build(session.sessionCredential, originalCredentials.requiredRemoteCredential(), remoteSessionRole))
+                        .orElseGet(() -> Credentials.build(session.sessionCredential, originalCredentials.requiredRemoteCredential())));
             });
         }
 

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/containers/S3Container.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/containers/S3Container.java
@@ -75,12 +75,13 @@ public class S3Container
                "Statement": [
                   {
                      "Effect": "Allow",
-                     "Action": [
-                        "s3:*"
-                     ],
-                     "Resource": [
-                        "arn:aws:s3:::*"
-                     ]
+                     "Action": "s3:*",
+                     "Resource": "arn:aws:s3:::*",
+                     "Condition": {
+                       "StringEquals": {
+                         "aws:principaltype": "AssumedRole"
+                       }
+                     }
                   }
                ]
             }


### PR DESCRIPTION
Before this PR, there was no way to ensure that the proxy was in fact
using a session to talk to Minio.

This PR changes the Minio policy configured
in the S3 container to only allow `policyUserCredential` access to S3 if using temporary credentials

