### PR TITLE
Require client to specify HTTP methods for pre-signed URLs

### DIFF
--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/RequestHeadersBuilder.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/RequestHeadersBuilder.java
@@ -33,8 +33,10 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.aws.proxy.server.rest.S3PresignController.PRESIGNED_URL_METHODS_HEADER_NAME;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static jakarta.ws.rs.core.Response.Status.LENGTH_REQUIRED;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 
@@ -50,7 +52,8 @@ final class RequestHeadersBuilder
             "connection",
             "amz-sdk-invocation-id",
             "amx-sdk-request",
-            "host");
+            "host",
+            PRESIGNED_URL_METHODS_HEADER_NAME.toLowerCase(ENGLISH));
 
     record InternalRequestHeaders(
             RequestHeaders requestHeaders,


### PR DESCRIPTION
When generating pre-signed URLs on HEAD requests is enabled, require additional request header `X-Trino-Pre-Signed-Url-Methods` which determines for which HTTP methods pre-signed URLs are generated.