### PR TITLE
Fix RequestLoggerController concurrency issues

### DIFF
--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/RequestLoggerController.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/RequestLoggerController.java
@@ -18,6 +18,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Throwables;
 import com.google.common.collect.EvictingQueue;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Queues;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.trino.aws.proxy.server.TrinoAwsProxyConfig;
@@ -146,7 +147,7 @@ public class RequestLoggerController
     public RequestLoggerController(TrinoAwsProxyConfig trinoAwsProxyConfig)
     {
         // *2 because we log request/response
-        saveQueue = EvictingQueue.create(trinoAwsProxyConfig.getRequestLoggerSavedQty() * 2);
+        saveQueue = Queues.synchronizedQueue(EvictingQueue.create(trinoAwsProxyConfig.getRequestLoggerSavedQty() * 2));
         saveQueueEnabled = (trinoAwsProxyConfig.getRequestLoggerSavedQty() > 0);
     }
 


### PR DESCRIPTION
There seems issues with threads on this line in aws-proxy - https://github.com/trinodb/aws-proxy/blob/main/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/RequestLoggerController.java#L307
Its using [EvictingQueue](https://guava.dev/releases/19.0/api/docs/com/google/common/collect/EvictingQueue.html) which is not thread-safe.

```
java.base/java.util.ArrayDeque.removeFirst(ArrayDeque.java:361)\n\tat 
java.base/java.util.ArrayDeque.remove(ArrayDeque.java:522)\n\tat 
com.google.common.collect.EvictingQueue.add(EvictingQueue.java:111)\n\tat 
io.trino.aws.proxy.server.rest.RequestLoggerController.logAndClear(RequestLoggerController.java:307)\n\tat 
io.trino.aws.proxy.server.rest.RequestLoggerController.internalNewRequestSession(RequestLoggerController.java:225)\n\tat 
io.trino.aws.proxy.server.rest.RequestLoggerController.lambda$newRequestSession$1(RequestLoggerController.java:175)
```

This PR makes EvictingQueue synchronised by adding a wrapper. Alternatively, we could have used a custom implementation of [ConcurrentLinkedQueue](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentLinkedQueue.html) (non-blocking, thread safe, natively unbounded) with a FIFO policy. The code would look something like this:
```
public static class ConcurrentLinkedQueueWithEviction<E>
{
    private final int maxSize;
    private AtomicInteger currentSize;
    private final Queue<E> queue;

    public ConcurrentLinkedQueueWithEviction(int maxSize)
    {
        this.maxSize = maxSize;
        currentSize = new AtomicInteger(0);
        queue = new ConcurrentLinkedQueue<>();
    }

    public boolean add(E e)
    {
        boolean isOperationSuccessful = queue.add(e);
        if (isOperationSuccessful) {
            currentSize.incrementAndGet();
            evict();
        }
        return isOperationSuccessful;
    }

    public Stream<E> stream()
    {
        return queue.stream();
    }

    public void clear()
    {
        queue.clear();
        currentSize.set(0);
    }

    private void evict()
    {
        while (currentSize.get() > maxSize) {
            queue.poll(); // Remove the oldest element (FIFO eviction)
            currentSize.decrementAndGet();
        }
    }
}
```

I did a performance test on my local for adding elements into in the queue (16k threads, 50 ops per thread, 100k queue size). The synchronised version of EvictingQueue performed consistently better than the custom implementation. So, decided to go with the synchronised version