### PR TITLE
Refactor to support Glue protocol (separate PR)

### DIFF
--- a/trino-aws-proxy-spi/src/main/java/io/trino/aws/proxy/spi/remote/RemoteUriFacade.java
+++ b/trino-aws-proxy-spi/src/main/java/io/trino/aws/proxy/spi/remote/RemoteUriFacade.java
@@ -13,17 +13,9 @@
  */
 package io.trino.aws.proxy.spi.remote;
 
-import jakarta.ws.rs.core.UriBuilder;
-
 import java.net.URI;
 
-public interface RemoteS3Facade
-        extends RemoteUriFacade
+public interface RemoteUriFacade
 {
-    URI buildEndpoint(UriBuilder uriBuilder, String path, String bucket, String region);
-
-    default URI remoteUri(String region)
-    {
-        return buildEndpoint(UriBuilder.newInstance(), "/", "", region);
-    }
+    URI remoteUri(String region);
 }

--- a/trino-aws-proxy-spi/src/main/java/io/trino/aws/proxy/spi/signing/SigningServiceType.java
+++ b/trino-aws-proxy-spi/src/main/java/io/trino/aws/proxy/spi/signing/SigningServiceType.java
@@ -13,16 +13,33 @@
  */
 package io.trino.aws.proxy.spi.signing;
 
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+import static io.trino.aws.proxy.spi.signing.SigningTrait.S3V4_SIGNER;
+import static io.trino.aws.proxy.spi.signing.SigningTrait.STREAM_CONTENT;
 import static java.util.Objects.requireNonNull;
 
-public record SigningServiceType(String serviceName)
+public record SigningServiceType(String serviceName, Set<SigningTrait> signingTraits)
 {
-    public static final SigningServiceType S3 = new SigningServiceType("s3");
+    public static final SigningServiceType S3 = new SigningServiceType("s3", S3V4_SIGNER, STREAM_CONTENT);
     public static final SigningServiceType STS = new SigningServiceType("sts");
     public static final SigningServiceType LOGS = new SigningServiceType("logs");
 
     public SigningServiceType
     {
         requireNonNull(serviceName, "serviceName is null");
+        signingTraits = ImmutableSet.copyOf(signingTraits);
+    }
+
+    public SigningServiceType(String serviceName, SigningTrait... signingTraits)
+    {
+        this(serviceName, ImmutableSet.copyOf(signingTraits));
+    }
+
+    public boolean hasTrait(SigningTrait signingTrait)
+    {
+        return signingTraits.contains(signingTrait);
     }
 }

--- a/trino-aws-proxy-spi/src/main/java/io/trino/aws/proxy/spi/signing/SigningTrait.java
+++ b/trino-aws-proxy-spi/src/main/java/io/trino/aws/proxy/spi/signing/SigningTrait.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.aws.proxy.spi.signing;
+
+public enum SigningTrait
+{
+    S3V4_SIGNER,
+    STREAM_CONTENT,
+}

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/TrinoAwsProxyConfig.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/TrinoAwsProxyConfig.java
@@ -18,7 +18,6 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.Optional;
@@ -34,7 +33,6 @@ public class TrinoAwsProxyConfig
     private Duration presignedUrlsDuration = new Duration(15, TimeUnit.MINUTES);
     private boolean generatePresignedUrlsOnHead = true;
     private String logsPath = "/api/v1/s3Proxy/logs";
-    private int requestLoggerSavedQty = 10000;
     private Optional<DataSize> maxPayloadSize = Optional.empty();
     private String statusPath = "/api/v1/s3Proxy/status";
 
@@ -119,20 +117,6 @@ public class TrinoAwsProxyConfig
     public String getLogsPath()
     {
         return logsPath;
-    }
-
-    @Min(0)
-    public int getRequestLoggerSavedQty()
-    {
-        return requestLoggerSavedQty;
-    }
-
-    @Config("aws.proxy.request.logger.saved-qty")
-    @ConfigDescription("Number of log entries to store")
-    public TrinoAwsProxyConfig setRequestLoggerSavedQty(int requestLoggerSavedQty)
-    {
-        this.requestLoggerSavedQty = requestLoggerSavedQty;
-        return this;
     }
 
     @NotNull

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/TrinoAwsProxyServerModule.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/TrinoAwsProxyServerModule.java
@@ -37,6 +37,7 @@ import io.trino.aws.proxy.server.credentials.http.HttpCredentialsModule;
 import io.trino.aws.proxy.server.remote.DefaultRemoteS3Module;
 import io.trino.aws.proxy.server.rest.LimitStreamController;
 import io.trino.aws.proxy.server.rest.ParamProvider;
+import io.trino.aws.proxy.server.rest.RequestLoggerConfig;
 import io.trino.aws.proxy.server.rest.RequestLoggerController;
 import io.trino.aws.proxy.server.rest.ResourceSecurityDynamicFeature;
 import io.trino.aws.proxy.server.rest.S3PresignController;
@@ -95,6 +96,7 @@ public class TrinoAwsProxyServerModule
     @Override
     protected void setup(Binder binder)
     {
+        configBinder(binder).bindConfig(RequestLoggerConfig.class);
         configBinder(binder).bindConfig(SigningControllerConfig.class);
         TrinoAwsProxyConfig builtConfig = buildConfigObject(TrinoAwsProxyConfig.class);
 

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/TrinoAwsProxyServerModule.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/TrinoAwsProxyServerModule.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
+import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.http.server.HttpServerBinder;
@@ -61,6 +62,7 @@ import io.trino.aws.proxy.spi.plugin.config.RemoteS3Config;
 import io.trino.aws.proxy.spi.plugin.config.S3RequestRewriterConfig;
 import io.trino.aws.proxy.spi.plugin.config.S3SecurityFacadeProviderConfig;
 import io.trino.aws.proxy.spi.remote.RemoteS3Facade;
+import io.trino.aws.proxy.spi.remote.RemoteUriFacade;
 import io.trino.aws.proxy.spi.rest.S3RequestRewriter;
 import io.trino.aws.proxy.spi.security.S3SecurityFacadeProvider;
 import org.glassfish.jersey.server.model.Resource;
@@ -82,6 +84,13 @@ public class TrinoAwsProxyServerModule
         extends AbstractConfigurationAwareModule
 {
     private static final Logger log = Logger.get(TrinoAwsProxyServerModule.class);
+
+    @Provides
+    @Singleton
+    public RemoteUriFacade remoteUriFacade(RemoteS3Facade remoteS3Facade)
+    {
+        return remoteS3Facade;
+    }
 
     @Override
     protected void setup(Binder binder)

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/credentials/CredentialsModule.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/credentials/CredentialsModule.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.aws.proxy.server.credentials;
+
+import com.google.inject.Binder;
+import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.log.Logger;
+import io.trino.aws.proxy.spi.credentials.AssumedRoleProvider;
+import io.trino.aws.proxy.spi.credentials.CredentialsProvider;
+import io.trino.aws.proxy.spi.credentials.Identity;
+import io.trino.aws.proxy.spi.credentials.StandardIdentity;
+import io.trino.aws.proxy.spi.plugin.config.AssumedRoleProviderConfig;
+import io.trino.aws.proxy.spi.plugin.config.CredentialsProviderConfig;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class CredentialsModule
+        extends AbstractConfigurationAwareModule
+{
+    private static final Logger log = Logger.get(CredentialsModule.class);
+
+    @Override
+    protected void setup(Binder binder)
+    {
+        binder.bind(CredentialsController.class).in(Scopes.SINGLETON);
+
+        // CredentialsProvider binder
+        configBinder(binder).bindConfig(CredentialsProviderConfig.class);
+        newOptionalBinder(binder, CredentialsProvider.class).setDefault().toProvider(() -> {
+            log.info("Using default %s NOOP implementation", CredentialsProvider.class.getSimpleName());
+            return CredentialsProvider.NOOP;
+        });
+        newOptionalBinder(binder, new TypeLiteral<Class<? extends Identity>>() {}).setDefault().toProvider(() -> {
+            log.info("Using %s identity type", StandardIdentity.class.getSimpleName());
+            return StandardIdentity.class;
+        });
+        newSetBinder(binder, com.fasterxml.jackson.databind.Module.class).addBinding().toProvider(JsonIdentityProvider.class).in(Scopes.SINGLETON);
+
+        // AssumedRoleProvider binder
+        configBinder(binder).bindConfig(AssumedRoleProviderConfig.class);
+        // AssumedRoleProvider provided implementations
+        newOptionalBinder(binder, AssumedRoleProvider.class).setDefault().toProvider(() -> {
+            log.info("Using default %s NOOP implementation", AssumedRoleProvider.class.getSimpleName());
+            return AssumedRoleProvider.NOOP;
+        });
+    }
+}

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/RequestLoggerConfig.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/RequestLoggerConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.aws.proxy.server.rest;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import jakarta.validation.constraints.Min;
+
+public class RequestLoggerConfig
+{
+    private int requestLoggerSavedQty = 10000;
+
+    @Min(0)
+    public int getRequestLoggerSavedQty()
+    {
+        return requestLoggerSavedQty;
+    }
+
+    @Config("aws.proxy.request.logger.saved-qty")
+    @ConfigDescription("Number of log entries to store")
+    public RequestLoggerConfig setRequestLoggerSavedQty(int requestLoggerSavedQty)
+    {
+        this.requestLoggerSavedQty = requestLoggerSavedQty;
+        return this;
+    }
+}

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/RequestLoggerController.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/RequestLoggerController.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Queues;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
-import io.trino.aws.proxy.server.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.spi.rest.Request;
 import io.trino.aws.proxy.spi.signing.SigningServiceType;
 import jakarta.annotation.PreDestroy;
@@ -144,11 +143,11 @@ public class RequestLoggerController
     private final boolean saveQueueEnabled;
 
     @Inject
-    public RequestLoggerController(TrinoAwsProxyConfig trinoAwsProxyConfig)
+    public RequestLoggerController(RequestLoggerConfig config)
     {
         // *2 because we log request/response
-        saveQueue = Queues.synchronizedQueue(EvictingQueue.create(trinoAwsProxyConfig.getRequestLoggerSavedQty() * 2));
-        saveQueueEnabled = (trinoAwsProxyConfig.getRequestLoggerSavedQty() > 0);
+        saveQueue = Queues.synchronizedQueue(EvictingQueue.create(config.getRequestLoggerSavedQty() * 2));
+        saveQueueEnabled = (config.getRequestLoggerSavedQty() > 0);
     }
 
     @PreDestroy

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/RestModule.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/RestModule.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.aws.proxy.server.rest;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import io.airlift.jaxrs.JaxrsBinder;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+
+public class RestModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        JaxrsBinder jaxrsBinder = jaxrsBinder(binder);
+        jaxrsBinder.bind(ParamProvider.class);
+        jaxrsBinder.bind(ResourceSecurityDynamicFeature.class);
+
+        configBinder(binder).bindConfig(RequestLoggerConfig.class);
+        binder.bind(RequestLoggerController.class).in(Scopes.SINGLETON);
+    }
+}

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoLogsResource.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoLogsResource.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.trino.aws.proxy.server.rest.RequestLoggerController.SaveEntry;
+import io.trino.aws.proxy.server.rest.ResourceSecurity.Logs;
 import io.trino.aws.proxy.server.rest.TrinoLogsResource.GetLogEventsResponse.Event;
 import io.trino.aws.proxy.spi.rest.Request;
 import jakarta.ws.rs.HeaderParam;
@@ -38,13 +39,12 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.trino.aws.proxy.server.rest.ResourceSecurity.AccessType.LOGS;
 import static io.trino.aws.proxy.spi.signing.SigningServiceType.S3;
 import static io.trino.aws.proxy.spi.signing.SigningServiceType.STS;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static java.util.Objects.requireNonNull;
 
-@ResourceSecurity(LOGS)
+@ResourceSecurity(Logs.class)
 public class TrinoLogsResource
 {
     private static final Set<String> DEFAULT_STREAMS = ImmutableSet.of(S3.serviceName(), STS.serviceName());

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoS3Resource.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoS3Resource.java
@@ -15,6 +15,7 @@ package io.trino.aws.proxy.server.rest;
 
 import com.google.inject.Inject;
 import io.trino.aws.proxy.server.TrinoAwsProxyConfig;
+import io.trino.aws.proxy.server.rest.ResourceSecurity.S3;
 import io.trino.aws.proxy.spi.rest.ParsedS3Request;
 import io.trino.aws.proxy.spi.rest.Request;
 import io.trino.aws.proxy.spi.signing.SigningMetadata;
@@ -33,10 +34,9 @@ import jakarta.ws.rs.core.Response;
 import java.util.Optional;
 
 import static io.trino.aws.proxy.server.rest.RequestBuilder.fromRequest;
-import static io.trino.aws.proxy.server.rest.ResourceSecurity.AccessType.S3;
 import static java.util.Objects.requireNonNull;
 
-@ResourceSecurity(S3)
+@ResourceSecurity(S3.class)
 public class TrinoS3Resource
 {
     private final TrinoS3ProxyClient proxyClient;

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoStatusResource.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoStatusResource.java
@@ -16,6 +16,7 @@ package io.trino.aws.proxy.server.rest;
 import com.google.inject.Inject;
 import com.sun.management.OperatingSystemMXBean;
 import io.airlift.node.NodeInfo;
+import io.trino.aws.proxy.server.rest.ResourceSecurity.Public;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HEAD;
 import jakarta.ws.rs.Produces;
@@ -25,11 +26,10 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 
 import static io.airlift.units.Duration.nanosSince;
-import static io.trino.aws.proxy.server.rest.ResourceSecurity.AccessType.PUBLIC;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static java.util.Objects.requireNonNull;
 
-@ResourceSecurity(PUBLIC)
+@ResourceSecurity(Public.class)
 public class TrinoStatusResource
 {
     private final NodeInfo nodeInfo;

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoStsResource.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoStsResource.java
@@ -19,6 +19,7 @@ import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.trino.aws.proxy.server.rest.AssumeRoleResponse.AssumeRoleResult;
 import io.trino.aws.proxy.server.rest.AssumeRoleResponse.AssumedRoleUser;
+import io.trino.aws.proxy.server.rest.ResourceSecurity.Sts;
 import io.trino.aws.proxy.spi.credentials.AssumedRoleProvider;
 import io.trino.aws.proxy.spi.credentials.EmulatedAssumedRole;
 import io.trino.aws.proxy.spi.rest.Request;
@@ -37,10 +38,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static io.trino.aws.proxy.server.rest.ResourceSecurity.AccessType.STS;
 import static java.util.Objects.requireNonNull;
 
-@ResourceSecurity(STS)
+@ResourceSecurity(Sts.class)
 public class TrinoStsResource
 {
     private static final Logger log = Logger.get(TrinoStsResource.class);

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestGenericRestRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestGenericRestRequests.java
@@ -21,6 +21,7 @@ import io.airlift.http.client.StatusResponseHandler.StatusResponse;
 import io.airlift.http.server.testing.TestingHttpServer;
 import io.airlift.units.Duration;
 import io.trino.aws.proxy.server.credentials.CredentialsController;
+import io.trino.aws.proxy.server.rest.RequestLoggerConfig;
 import io.trino.aws.proxy.server.rest.RequestLoggerController;
 import io.trino.aws.proxy.server.signing.InternalSigningController;
 import io.trino.aws.proxy.server.signing.SigningControllerConfig;
@@ -115,7 +116,7 @@ public class TestGenericRestRequests
         this.signingController = new InternalSigningController(
                 new CredentialsController(new TestingRemoteS3Facade(), credentialsRolesProvider),
                 new SigningControllerConfig().setMaxClockDrift(new Duration(10, TimeUnit.SECONDS)),
-                new RequestLoggerController(new TrinoAwsProxyConfig()));
+                new RequestLoggerController(new RequestLoggerConfig()));
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.testingCredentials = requireNonNull(testingCredentials, "testingCredentials is null");
         this.storageClient = requireNonNull(storageClient, "storageClient is null");

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestHttpChunked.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestHttpChunked.java
@@ -19,6 +19,7 @@ import io.airlift.http.client.Request;
 import io.airlift.http.server.testing.TestingHttpServer;
 import io.airlift.units.Duration;
 import io.trino.aws.proxy.server.credentials.CredentialsController;
+import io.trino.aws.proxy.server.rest.RequestLoggerConfig;
 import io.trino.aws.proxy.server.rest.RequestLoggerController;
 import io.trino.aws.proxy.server.signing.InternalSigningController;
 import io.trino.aws.proxy.server.signing.SigningControllerConfig;
@@ -280,7 +281,7 @@ public class TestHttpChunked
         InternalSigningController signingController = new InternalSigningController(
                 new CredentialsController(new TestingRemoteS3Facade(), credentialsRolesProvider),
                 new SigningControllerConfig().setMaxClockDrift(new Duration(10, TimeUnit.SECONDS)),
-                new RequestLoggerController(new TrinoAwsProxyConfig()));
+                new RequestLoggerController(new RequestLoggerConfig()));
         RequestAuthorization requestAuthorization = signingController.signRequest(new SigningMetadata(SigningServiceType.S3, Credentials.build(VALID_CREDENTIAL, testingCredentials.requiredRemoteCredential()), Optional.empty()),
                 "us-east-1", requestDate, Optional.empty(), Credentials::emulated, requestUri, requestHeaderBuilder.build(), ImmutableMultiMap.empty(), "PUT").signingAuthorization();
 

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/rest/TestRequestLoggerController.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/rest/TestRequestLoggerController.java
@@ -14,7 +14,6 @@
 package io.trino.aws.proxy.server.rest;
 
 import com.google.common.collect.ImmutableSet;
-import io.trino.aws.proxy.server.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.rest.RequestLoggerController.SaveEntry;
 import io.trino.aws.proxy.spi.rest.Request;
 import io.trino.aws.proxy.spi.rest.RequestContent;
@@ -38,7 +37,7 @@ public class TestRequestLoggerController
     @Test
     public void testSavedEntries()
     {
-        RequestLoggerController controller = new RequestLoggerController(new TrinoAwsProxyConfig());
+        RequestLoggerController controller = new RequestLoggerController(new RequestLoggerConfig());
         try (RequestLoggingSession session = controller.newRequestSession(dummyRequest(), SigningServiceType.S3)) {
             session.logProperty("one", 1);
             session.logProperty("two", 2);
@@ -59,8 +58,8 @@ public class TestRequestLoggerController
     @Test
     public void testSavedEntriesOverflow()
     {
-        TrinoAwsProxyConfig trinoAwsProxyConfig = new TrinoAwsProxyConfig().setRequestLoggerSavedQty(5);
-        RequestLoggerController controller = new RequestLoggerController(trinoAwsProxyConfig);
+        RequestLoggerConfig requestLoggerConfig = new RequestLoggerConfig().setRequestLoggerSavedQty(5);
+        RequestLoggerController controller = new RequestLoggerController(requestLoggerConfig);
         IntStream.range(0, 10).forEach(index -> {
             try (RequestLoggingSession session = controller.newRequestSession(dummyRequest(), SigningServiceType.S3)) {
                 session.logProperty("index", index);

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/signing/TestSigningController.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/signing/TestSigningController.java
@@ -14,8 +14,8 @@
 package io.trino.aws.proxy.server.signing;
 
 import io.airlift.units.Duration;
-import io.trino.aws.proxy.server.TrinoAwsProxyConfig;
 import io.trino.aws.proxy.server.credentials.CredentialsController;
+import io.trino.aws.proxy.server.rest.RequestLoggerConfig;
 import io.trino.aws.proxy.server.rest.RequestLoggerController;
 import io.trino.aws.proxy.server.testing.TestingRemoteS3Facade;
 import io.trino.aws.proxy.spi.credentials.Credential;
@@ -48,7 +48,7 @@ public class TestSigningController
     private static final Credentials CREDENTIALS = Credentials.build(new Credential("THIS_IS_AN_ACCESS_KEY", "THIS_IS_A_SECRET_KEY"));
     private static final CredentialsProvider CREDENTIALS_PROVIDER = (_, _) -> Optional.of(CREDENTIALS);
     private static final CredentialsController CREDENTIALS_CONTROLLER = new CredentialsController(new TestingRemoteS3Facade(), CREDENTIALS_PROVIDER);
-    private static final SigningController LARGE_DRIFT_SIGNING_CONTROLLER = new InternalSigningController(CREDENTIALS_CONTROLLER, new SigningControllerConfig().setMaxClockDrift(new Duration(99999, TimeUnit.DAYS)), new RequestLoggerController(new TrinoAwsProxyConfig()));
+    private static final SigningController LARGE_DRIFT_SIGNING_CONTROLLER = new InternalSigningController(CREDENTIALS_CONTROLLER, new SigningControllerConfig().setMaxClockDrift(new Duration(99999, TimeUnit.DAYS)), new RequestLoggerController(new RequestLoggerConfig()));
 
     @Test
     public void testRootLs()
@@ -177,7 +177,7 @@ public class TestSigningController
 
     private static void tryValidateRequestOfAgeAndExpiry(Instant requestDate, Optional<Instant> requestExpiry, Duration maxClockDrift)
     {
-        RequestLoggerController requestLoggerController = new RequestLoggerController(new TrinoAwsProxyConfig());
+        RequestLoggerController requestLoggerController = new RequestLoggerController(new RequestLoggerConfig());
         SigningController requestSigningController = new InternalSigningController(CREDENTIALS_CONTROLLER, new SigningControllerConfig().setMaxClockDrift(maxClockDrift), requestLoggerController);
 
         URI requestUri = URI.create("http://dummy-url");


### PR DESCRIPTION
## Introduce RemoteUriFacade

Abstract RemoteS3Facade's `remoteUri()` into a new interface
that can be used/injected independently of S3 implementations.

## Give Request logger its own config

Move the Request logging config into separate config class

##  Abstract some common bindings of 

Abstract new static methods so portions of module can be used in other contexts
