### PR TITLE
Handle streaming exceptions as bad requests instead of internal errors

### DIFF
--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/HashCheckInputStream.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/HashCheckInputStream.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static java.util.Objects.requireNonNull;
 
@@ -106,8 +107,7 @@ class HashCheckInputStream
         bytesRead += count;
         expectedLength.ifPresent(expected -> {
             if (bytesRead > expected) {
-                log.debug("More bytes read than expected. Expected: %s, Actual: %s", expected, bytesRead);
-                throw new WebApplicationException(UNAUTHORIZED);
+                throw new WebApplicationException("More bytes read than expected. Expected: %s, Actual: %s".formatted(expected, bytesRead), BAD_REQUEST);
             }
 
             if (bytesRead == expected) {

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/StreamingResponseHandler.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/StreamingResponseHandler.java
@@ -101,8 +101,10 @@ class StreamingResponseHandler
     {
         switch (result) {
             case WebApplicationException exception -> resume(exception.getResponse());
-            case Throwable exception when Throwables.getRootCause(exception) instanceof WebApplicationException webApplicationException -> resume(webApplicationException.getResponse());
-            case Throwable exception -> resume(jakarta.ws.rs.core.Response.status(INTERNAL_SERVER_ERROR.getStatusCode(), Optional.ofNullable(exception.getMessage()).orElse("Unknown error")).build());
+            case Throwable exception when Throwables.getRootCause(exception) instanceof WebApplicationException webApplicationException ->
+                    resume(webApplicationException.getResponse());
+            case Throwable exception ->
+                    resume(jakarta.ws.rs.core.Response.status(INTERNAL_SERVER_ERROR.getStatusCode(), Optional.ofNullable(exception.getMessage()).orElse("Unknown error")).build());
             default -> {
                 if (hasBeenResumed.compareAndSet(false, true)) {
                     asyncResponse.resume(result);

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestGenericRestRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestGenericRestRequests.java
@@ -182,7 +182,7 @@ public class TestGenericRestRequests
 
         // Final chunk has an invalid size
         Function<String, String> changeSizeOfFinalChunk = chunked -> chunked.replaceFirst("\\r\\n0;chunk-signature=(\\w+)", "\r\n1;chunk-signature=$1");
-        assertThat(doAwsChunkedUpload(bucket, fileKey, LOREM_IPSUM, 2, validCredential, changeSizeOfFinalChunk).getStatusCode()).isEqualTo(500);
+        assertThat(doAwsChunkedUpload(bucket, fileKey, LOREM_IPSUM, 2, validCredential, changeSizeOfFinalChunk).getStatusCode()).isEqualTo(400);
         assertFileNotInS3(storageClient, bucket, fileKey);
 
         // First chunk has an invalid size
@@ -198,7 +198,7 @@ public class TestGenericRestRequests
             }
             return "%s%s".formatted(newSizeAsString, chunked.substring(firstChunkIdx));
         };
-        assertThat(doAwsChunkedUpload(bucket, fileKey, LOREM_IPSUM, 2, validCredential, changeSizeOfFirstChunk).getStatusCode()).isEqualTo(500);
+        assertThat(doAwsChunkedUpload(bucket, fileKey, LOREM_IPSUM, 2, validCredential, changeSizeOfFirstChunk).getStatusCode()).isEqualTo(400);
         assertFileNotInS3(storageClient, bucket, fileKey);
 
         // Change the signature of each of the chunks
@@ -269,24 +269,24 @@ public class TestGenericRestRequests
         storageClient.createBucket(r -> r.bucket(bucket).build());
 
         // Illegal signature and no final chunk
-        testAwsChunkedIllegalChunks(bucket, "no-final-chunk", buildFakeChunk(longDummyContent, longDummyContent.length()), longDummyContent.length(), 500);
+        testAwsChunkedIllegalChunks(bucket, "no-final-chunk", buildFakeChunk(longDummyContent, longDummyContent.length()), longDummyContent.length(), 400);
         // Illegal signature with a final chunk
         testAwsChunkedIllegalChunks(bucket, "with-final-chunk", "%s%s".formatted(buildFakeChunk(longDummyContent, longDummyContent.length()), buildFakeChunk("", 0)), longDummyContent.length(), 401);
         // Illegal signature and no final chunk - more chunked data than we report in the x-amz-decoded-content-length header
-        testAwsChunkedIllegalChunks(bucket, "no-final-chunk-more-data-than-headers-indicate", buildFakeChunk(longDummyContent, longDummyContent.length()), 4096, 500);
+        testAwsChunkedIllegalChunks(bucket, "no-final-chunk-more-data-than-headers-indicate", buildFakeChunk(longDummyContent, longDummyContent.length()), 4096, 400);
 
         // Illegal signature with a final chunk - more chunked data than we report in the x-amz-decoded-content-length header
-        testAwsChunkedIllegalChunks(bucket, "with-final-chunk-more-data-than-headers-indicate", "%s%s".formatted(buildFakeChunk(longDummyContent, longDummyContent.length()), buildFakeChunk("", 0)), 4096, 500);
+        testAwsChunkedIllegalChunks(bucket, "with-final-chunk-more-data-than-headers-indicate", "%s%s".formatted(buildFakeChunk(longDummyContent, longDummyContent.length()), buildFakeChunk("", 0)), 4096, 400);
 
         // Illegal signature and no final chunk - chunk misreports its size
-        testAwsChunkedIllegalChunks(bucket, "no-final-chunk-chunk-underreports-size", buildFakeChunk(longDummyContent, 4096), 4096, 500);
+        testAwsChunkedIllegalChunks(bucket, "no-final-chunk-chunk-underreports-size", buildFakeChunk(longDummyContent, 4096), 4096, 400);
         // Illegal signature with a final chunk - chunk misreports its size
-        testAwsChunkedIllegalChunks(bucket, "with-final-chunk-chunk-underreports-size", "%s%s".formatted(buildFakeChunk(longDummyContent, 4096), buildFakeChunk("", 0)), 4096, 500);
+        testAwsChunkedIllegalChunks(bucket, "with-final-chunk-chunk-underreports-size", "%s%s".formatted(buildFakeChunk(longDummyContent, 4096), buildFakeChunk("", 0)), 4096, 400);
 
         // Illegal signature and no final chunk - chunk misreports its size
-        testAwsChunkedIllegalChunks(bucket, "no-final-chunk-chunk-overreports-size", buildFakeChunk(longDummyContent, 9_000_000), 4096, 500);
+        testAwsChunkedIllegalChunks(bucket, "no-final-chunk-chunk-overreports-size", buildFakeChunk(longDummyContent, 9_000_000), 4096, 400);
         // Illegal signature with a final chunk - chunk misreports its size
-        testAwsChunkedIllegalChunks(bucket, "with-final-chunk-chunk-overreports-size", "%s%s".formatted(buildFakeChunk(longDummyContent, 9_000_000), buildFakeChunk("", 0)), 4096, 500);
+        testAwsChunkedIllegalChunks(bucket, "with-final-chunk-chunk-overreports-size", "%s%s".formatted(buildFakeChunk(longDummyContent, 9_000_000), buildFakeChunk("", 0)), 4096, 400);
         Thread.sleep(1000);
         assertThat(listFilesInS3Bucket(storageClient, bucket)).isEmpty();
     }

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/rest/TestAwsChunkedInputStream.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/rest/TestAwsChunkedInputStream.java
@@ -282,7 +282,7 @@ public class TestAwsChunkedInputStream
     private static void testIllegalAwsChunkedData(String chunkedData, int decodedContentLength, TestingChunkSigningSession signingSession, ChunkReader readerMethod)
     {
         ByteArrayOutputStream testOutput = new ByteArrayOutputStream();
-        assertThatThrownBy(() -> readerMethod.read(chunkedData, decodedContentLength, signingSession, testOutput)).isInstanceOfAny(IllegalStateException.class, WebApplicationException.class, IOException.class);
+        assertThatThrownBy(() -> readerMethod.read(chunkedData, decodedContentLength, signingSession, testOutput)).isInstanceOfAny(WebApplicationException.class, IOException.class);
         assertThat(testOutput.toByteArray().length).isLessThan(decodedContentLength);
     }
 
@@ -377,7 +377,7 @@ public class TestAwsChunkedInputStream
         InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
         byte[] tmp = new byte[5];
         // altered from original test. Our AwsChunkedInputStream is improved and throws when the final chunk is missing or bad
-        assertThrows(IOException.class, () -> in.read(tmp));
+        assertThrows(WebApplicationException.class, () -> in.read(tmp));
     }
 
     // Truncated stream (missing closing CRLF)
@@ -393,7 +393,7 @@ public class TestAwsChunkedInputStream
                     InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
                     byte[] tmp = new byte[5];
                     // altered from original test. Our AwsChunkedInputStream is improved and throws when the final chunk is missing or bad
-                    assertThrows(IOException.class, () -> in.read(tmp));
+                    assertThrows(WebApplicationException.class, () -> in.read(tmp));
                     try {
                         in.close();
                     }
@@ -413,7 +413,7 @@ public class TestAwsChunkedInputStream
         InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
         byte[] buffer = new byte[300];
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        assertThrows(IOException.class, () -> {
+        assertThrows(WebApplicationException.class, () -> {
             int len;
             while ((len = in.read(buffer)) > 0) {
                 out.write(buffer, 0, len);
@@ -431,7 +431,7 @@ public class TestAwsChunkedInputStream
         byte[] rawBytes = s.getBytes(UTF_8);
         ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
         InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
-        assertThrows(IOException.class, in::read);
+        assertThrows(WebApplicationException.class, in::read);
         in.close();
     }
 
@@ -444,7 +444,7 @@ public class TestAwsChunkedInputStream
         byte[] rawBytes = s.getBytes(UTF_8);
         ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
         InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
-        assertThrows(IOException.class, in::read);
+        assertThrows(WebApplicationException.class, in::read);
         in.close();
     }
 
@@ -457,7 +457,7 @@ public class TestAwsChunkedInputStream
         byte[] rawBytes = s.getBytes(UTF_8);
         ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
         InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
-        assertThrows(IOException.class, in::read);
+        assertThrows(WebApplicationException.class, in::read);
         in.close();
     }
 
@@ -472,20 +472,18 @@ public class TestAwsChunkedInputStream
         InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
         byte[] buffer = new byte[300];
         assertEquals(2, in.read(buffer));
-        assertThrows(IOException.class, () -> in.read(buffer));
+        assertThrows(WebApplicationException.class, () -> in.read(buffer));
         in.close();
     }
 
     @Test
     public void testCorruptChunkedInputStreamClose()
-            throws IOException
     {
         String s = "whatever;chunk-signature=0\r\n01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\n\r\n";
         byte[] rawBytes = s.getBytes(UTF_8);
         ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
-        try (InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length)) {
-            assertThrows(IOException.class, in::read);
-        }
+        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
+        assertThrows(WebApplicationException.class, in::read);
     }
 
     @Test


### PR DESCRIPTION
Currently the proxy handles most streaming issues due to mismatch between declared content length and uploaded content length as INTERNAL_ERRORs, except for when it's a STANDARD or W3C_CHUNKED and uploaded > content length, then this is handled as UNAUTHORIZED.

This PR is suggesting handle all of the above as BAD_REQUEST. 