### PR TITLE
Respect range parameter for getObject in presign aware S3 clients

### DIFF
--- a/trino-aws-proxy-spark3/src/main/java/io/trino/aws/proxy/spark3/PresignAwareAmazonS3.java
+++ b/trino-aws-proxy-spark3/src/main/java/io/trino/aws/proxy/spark3/PresignAwareAmazonS3.java
@@ -626,6 +626,8 @@ class PresignAwareAmazonS3
         return getPresignedUrl("GET", getObjectRequest.getBucketName(), getObjectRequest.getKey())
                 .map(presigned -> {
                     PresignedUrlDownloadRequest presignedUrlDownloadRequest = new PresignedUrlDownloadRequest(presigned.url);
+                    Optional.ofNullable(getObjectRequest.getRange())
+                            .ifPresent(range -> presignedUrlDownloadRequest.withRange(range[0], range[1]));
                     return delegate.download(presignedUrlDownloadRequest).getS3Object();
                 })
                 .orElseGet(() -> delegate.getObject(getObjectRequest));
@@ -638,6 +640,8 @@ class PresignAwareAmazonS3
         return getPresignedUrl("GET", getObjectRequest.getBucketName(), getObjectRequest.getKey())
                 .map(presigned -> {
                     PresignedUrlDownloadRequest presignedUrlDownloadRequest = new PresignedUrlDownloadRequest(presigned.url);
+                    Optional.ofNullable(getObjectRequest.getRange())
+                            .ifPresent(range -> presignedUrlDownloadRequest.withRange(range[0], range[1]));
                     delegate.download(presignedUrlDownloadRequest, destinationFile);
                     return presigned.objectMetadata;
                 })

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestDatabaseSecurity.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestDatabaseSecurity.java
@@ -103,6 +103,9 @@ public class TestDatabaseSecurity
     public void testDatabaseSecurity()
             throws Exception
     {
+        // create the test bucket
+        s3Client.createBucket(r -> r.bucket("test"));
+
         createDatabaseAndTable(s3Client, pySparkContainer);
 
         clearInputStreamAndClose(inputToContainerStdin(pySparkContainer.containerId(), "spark.sql(\"select * from %s.%s\").show()".formatted(DATABASE_NAME, TABLE_NAME)), line -> line.equals("|    John Galt| 28|"));


### PR DESCRIPTION
If present, the range parameter from GetObjectRequest should be added to PresignedUrlDownloadRequest, so that the client gets the expected bytes.